### PR TITLE
Make GDB compile in native mode

### DIFF
--- a/gdb/config/riscv/linux.mh
+++ b/gdb/config/riscv/linux.mh
@@ -21,7 +21,8 @@
 NAT_FILE= config/nm-linux.h
 NATDEPFILES= inf-ptrace.o fork-child.o riscv-linux-nat.o \
 	proc-service.o linux-thread-db.o linux-nat.o linux-fork.o \
-	linux-procfs.o linux-ptrace.o linux-osdata.o linux-waitpid.o
+	linux-procfs.o linux-ptrace.o linux-osdata.o linux-waitpid.o \
+	linux-namespaces.o linux-personality.o
 NAT_CDEPS = $(srcdir)/proc-service.list
 
 # The dynamically loaded libthread_db needs access to symbols in the

--- a/gdb/configure.host
+++ b/gdb/configure.host
@@ -64,6 +64,7 @@ m68*)			gdb_host_cpu=m68k ;;
 m88*)			gdb_host_cpu=m88k ;;
 mips*)			gdb_host_cpu=mips ;;
 powerpc* | rs6000)	gdb_host_cpu=powerpc ;;
+riscv*)                 gdb_host_cpu=riscv ;;
 sparcv9 | sparc64)	gdb_host_cpu=sparc ;;
 s390*)			gdb_host_cpu=s390 ;;
 sh*)			gdb_host_cpu=sh ;;
@@ -146,6 +147,8 @@ powerpc64*-*-linux*)	gdb_host=ppc64-linux
                         fi
 			;;
 powerpc*-*-linux*)	gdb_host=linux ;;
+
+riscv*-linux*)          gdb_host=linux ;;
 
 s390*-*-linux*)		gdb_host=linux ;;
 

--- a/gdb/riscv-linux-tdep.c
+++ b/gdb/riscv-linux-tdep.c
@@ -60,10 +60,13 @@ riscv_linux_init_abi (struct gdbarch_info info, struct gdbarch *gdbarch)
   linux_init_abi (info, gdbarch);
 
   /* GNU/Linux uses SVR4-style shared libraries.  */
+  /* FIXME: This '0' should actually be a check to see if we're on
+     rv32, but I can't figure out how to hook that up (it's in
+     gdbarch_tdep, which we don't have here). */
   set_solib_svr4_fetch_link_map_offsets
-    (gdbarch, (IS_RV32I (riscv_abi (gdbarch)) ?
+    (gdbarch, (0) ?
       svr4_ilp32_fetch_link_map_offsets :
-      svr4_lp64_fetch_link_map_offsets));
+      svr4_lp64_fetch_link_map_offsets);
 
   set_gdbarch_iterate_over_regset_sections
     (gdbarch, riscv_linux_iterate_over_regset_sections);

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1157,7 +1157,7 @@ riscv_gdbarch_init (struct gdbarch_info  info,
       tdesc_data = tdesc_data_alloc ();
 
       valid_p = 1;
-      for (i = RISCV_ZERO_REGNUM; i <= RISCV_LAST_REGNUM; ++i)
+      for (i = RISCV_ZERO_REGNUM; i < RISCV_LAST_REGNUM; ++i)
 	valid_p &= tdesc_numbered_register (feature, tdesc_data, i, riscv_gdb_reg_names[i]);
 
       if (!valid_p)

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -158,12 +158,6 @@ static const struct register_alias riscv_register_aliases[] =
   { "ft11", 64 },
 };
 
-static inline int
-riscv_isa_regsize (struct gdbarch *gdbarch)
-{
-  return gdbarch_tdep (gdbarch)->register_size;
-}
-
 static const gdb_byte *
 riscv_breakpoint_from_pc (struct gdbarch *gdbarch,
 			  CORE_ADDR      *bp_addr,

--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -90,4 +90,10 @@ struct gdbarch_tdep
   int register_size;
 };
 
+static inline int
+riscv_isa_regsize (struct gdbarch *gdbarch)
+{
+  return gdbarch_tdep (gdbarch)->register_size;
+}
+
 #endif /* RISCV_TDEP_H */


### PR DESCRIPTION
It looks like the merge of the native GDB patches didn't go correctly and ended up producing something that doesn't even build.  This PR submits some patches that make the RISC-V native GDB port build.  I haven't tested anything (and the last patch is a mess), but I thought I'd get this out there just in case anyone was working on it because I might not have time to finish this for a bit.

At least it can't be worse than code that doesn't build... :)