### PR TITLE
Allow access to all CSRs through $csrNN, and access to GPRs using $xN (cleaner history)

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -65,7 +65,7 @@ struct riscv_frame_cache
   struct trad_frame_saved_reg *saved_regs;
 };
 
-static const char * const riscv_gdb_reg_names[RISCV_LAST_FP_REGNUM+1] =
+static const char * const riscv_gdb_reg_names[RISCV_LAST_FP_REGNUM + 1] =
 {
   "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",
   "x8",  "x9",  "x10", "x11", "x12", "x13", "x14", "x15",
@@ -152,7 +152,7 @@ static const struct register_alias riscv_register_aliases[] =
   { "ft9", 62 },
   { "ft10", 63 },
   { "ft11", 64 },
-#define DECLARE_CSR(name, num) { #name, (num)+65 },
+#define DECLARE_CSR(name, num) { #name, (num) + 65 },
 #include "opcode/riscv-opc.h"
 #undef DECLARE_CSR
 };
@@ -616,7 +616,7 @@ riscv_register_reggroup_p (struct gdbarch  *gdbarch,
   int raw_p;
   unsigned int i;
 
-  /* Used by 'info registers' and 'info registers <groupname>'. */
+  /* Used by 'info registers' and 'info registers <groupname>'.  */
 
   if (gdbarch_register_name (gdbarch, regnum) == NULL
       || gdbarch_register_name (gdbarch, regnum)[0] == '\0')
@@ -625,7 +625,7 @@ riscv_register_reggroup_p (struct gdbarch  *gdbarch,
   if (reggroup == all_reggroup) {
     if (regnum < RISCV_FIRST_CSR_REGNUM)
       return 1;
-    /* Only include CSRs that have aliases. */
+    /* Only include CSRs that have aliases.  */
     for (i = 0; i < ARRAY_SIZE (riscv_register_aliases); ++i) {
 	if (regnum == riscv_register_aliases[i].regnum)
           return 1;
@@ -641,7 +641,7 @@ riscv_register_reggroup_p (struct gdbarch  *gdbarch,
   else if (reggroup == restore_reggroup || reggroup == save_reggroup)
     return regnum <= RISCV_LAST_FP_REGNUM;
   else if (reggroup == system_reggroup) {
-    /* Only include CSRs that have aliases. */
+    /* Only include CSRs that have aliases.  */
     if (regnum < RISCV_FIRST_CSR_REGNUM || regnum > RISCV_LAST_CSR_REGNUM)
       return 0;
     for (i = 0; i < ARRAY_SIZE (riscv_register_aliases); ++i) {
@@ -662,7 +662,7 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
 			    int                regnum,
 			    int                all)
 {
-  /* Use by 'info all-registers'. */
+  /* Use by 'info all-registers'.  */
   struct reggroup *reggroup;
 
   if (regnum != -1)
@@ -753,7 +753,7 @@ riscv_scan_prologue (struct gdbarch *gdbarch,
   int seen_sp_adjust = 0;
   int load_immediate_bytes = 0;
 
-  /* Can be called when there's no process, and hence when there's no THIS_FRAME. */
+  /* Can be called when there's no process, and hence when there's no THIS_FRAME.  */
   if (this_frame != NULL)
     sp = get_frame_register_signed (this_frame, RISCV_SP_REGNUM);
   else
@@ -1184,7 +1184,6 @@ riscv_gdbarch_init (struct gdbarch_info  info,
       const struct tdesc_feature *feature;
       struct tdesc_arch_data *tdesc_data;
       int valid_p;
-      char buf[20];
 
       feature = tdesc_find_feature (info.target_desc, "org.gnu.gdb.riscv.cpu");
       if (feature == NULL)
@@ -1195,10 +1194,11 @@ riscv_gdbarch_init (struct gdbarch_info  info,
       valid_p = 1;
       for (i = RISCV_ZERO_REGNUM; i <= RISCV_LAST_FP_REGNUM; ++i)
         valid_p &= tdesc_numbered_register (feature, tdesc_data, i,
-            riscv_gdb_reg_names[i]);
+                                            riscv_gdb_reg_names[i]);
       for (i = RISCV_FIRST_CSR_REGNUM; i <= RISCV_LAST_CSR_REGNUM; ++i)
         {
-          sprintf(buf, "csr%d", i - RISCV_FIRST_CSR_REGNUM);
+          char buf[20];
+          sprintf (buf, "csr%d", i - RISCV_FIRST_CSR_REGNUM);
           valid_p &= tdesc_numbered_register (feature, tdesc_data, i, buf);
         }
 

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -599,7 +599,7 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
     {
       /* Print one specified register.  */
       gdb_assert (regnum < RISCV_LAST_REGNUM);
-      if ('\0' == *(riscv_register_name (gdbarch, regnum)))
+      if (NULL == riscv_register_name (gdbarch, regnum))
 	error (_("Not a valid register for the current processor type"));
       riscv_print_register_formatted (file, frame, regnum);
       fprintf_filtered (file, "\n");
@@ -607,7 +607,7 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
   else
     for (regnum = 0; regnum < RISCV_LAST_REGNUM; ++regnum)
       {
-	if ('\0' == *(riscv_register_name (gdbarch, regnum)))
+	if (NULL == riscv_register_name (gdbarch, regnum))
 	  error (_("Not a valid register for the current processor type"));
 
 	/* Zero never changes, so might as well hide by default.  */

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1150,7 +1150,7 @@ riscv_gdbarch_init (struct gdbarch_info  info,
   set_gdbarch_sp_regnum (gdbarch, RISCV_SP_REGNUM);
   set_gdbarch_pc_regnum (gdbarch, RISCV_PC_REGNUM);
   set_gdbarch_ps_regnum (gdbarch, RISCV_FP_REGNUM);
-  set_gdbarch_deprecated_fp_regnum (gdbarch, RISCV_FIRST_FP_REGNUM);
+  set_gdbarch_deprecated_fp_regnum (gdbarch, RISCV_FP_REGNUM);
 
   /* Functions to supply register information.  */
   set_gdbarch_register_name (gdbarch, riscv_register_name);

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -65,7 +65,7 @@ struct riscv_frame_cache
   struct trad_frame_saved_reg *saved_regs;
 };
 
-static const char * const riscv_gdb_reg_names[RISCV_NUM_REGS] =
+static const char * const riscv_gdb_reg_names[RISCV_LAST_FP_REGNUM+1] =
 {
   "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",
   "x8",  "x9",  "x10", "x11", "x12", "x13", "x14", "x15",
@@ -76,10 +76,6 @@ static const char * const riscv_gdb_reg_names[RISCV_NUM_REGS] =
   "f8",  "f9",  "f10", "f11", "f12", "f13", "f14", "f15",
   "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
   "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",
-
-#define DECLARE_CSR(name, num) #name,
-#include "opcode/riscv-opc.h"
-#undef DECLARE_CSR
 };
 
 struct register_alias
@@ -156,6 +152,9 @@ static const struct register_alias riscv_register_aliases[] =
   { "ft9", 62 },
   { "ft10", 63 },
   { "ft11", 64 },
+#define DECLARE_CSR(name, num) { #name, (num)+65 },
+#include "opcode/riscv-opc.h"
+#undef DECLARE_CSR
 };
 
 static const gdb_byte *
@@ -193,18 +192,27 @@ riscv_register_name (struct gdbarch *gdbarch,
 		     int             regnum)
 {
   int i;
+  static char buf[20];
 
   if (tdesc_has_registers (gdbarch_target_desc (gdbarch)))
     return tdesc_register_name (gdbarch, regnum);
-  else if (regnum >= 0 && regnum < RISCV_LAST_REGNUM)
+  if (regnum >= RISCV_ZERO_REGNUM && regnum <= RISCV_LAST_REGNUM)
     {
       for (i = 0; i < ARRAY_SIZE (riscv_register_aliases); ++i)
 	if (regnum == riscv_register_aliases[i].regnum)
 	  return riscv_register_aliases[i].name;
-      return riscv_gdb_reg_names[regnum];
     }
-  else
-    return NULL;
+
+  if (regnum >= RISCV_ZERO_REGNUM && regnum <= RISCV_LAST_FP_REGNUM)
+      return riscv_gdb_reg_names[regnum];
+
+  if (regnum >= RISCV_FIRST_CSR_REGNUM && regnum <= RISCV_LAST_CSR_REGNUM)
+    {
+      sprintf(buf, "csr%d", regnum - RISCV_FIRST_CSR_REGNUM);
+      return buf;
+    }
+
+  return NULL;
 }
 
 static void
@@ -595,32 +603,18 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
 			    int                regnum,
 			    int                all)
 {
-  if (regnum != -1)
+  if (regnum == -1)
     {
-      /* Print one specified register.  */
-      gdb_assert (regnum < RISCV_LAST_REGNUM);
-      if (NULL == riscv_register_name (gdbarch, regnum))
-	error (_("Not a valid register for the current processor type"));
-      riscv_print_register_formatted (file, frame, regnum);
-      fprintf_filtered (file, "\n");
+      error (_("riscv_print_registers_info shouldn't be asked to print all registers."));
+      error (_("That should be handled by register groups."));
     }
-  else
-    for (regnum = 0; regnum < RISCV_LAST_REGNUM; ++regnum)
-      {
-	if (NULL == riscv_register_name (gdbarch, regnum))
-	  error (_("Not a valid register for the current processor type"));
 
-	/* Zero never changes, so might as well hide by default.  */
-	if (regnum == RISCV_ZERO_REGNUM && !all)
-	  continue;
-
-	/* Only show the main integer register set by default.  */
-	if (all || regnum < RISCV_FIRST_FP_REGNUM)
-	  {
-	    riscv_print_register_formatted (file, frame, regnum);
-	    fprintf_filtered (file, "\n");
-	  }
-      }
+  /* Print one specified register.  */
+  gdb_assert (regnum < RISCV_LAST_REGNUM);
+  if (NULL == riscv_register_name (gdbarch, regnum))
+    error (_("Not a valid register for the current processor type"));
+  riscv_print_register_formatted (file, frame, regnum);
+  fprintf_filtered (file, "\n");
 }
 
 static int
@@ -630,14 +624,22 @@ riscv_register_reggroup_p (struct gdbarch  *gdbarch,
 {
   int float_p;
   int raw_p;
+  unsigned int i;
 
   if (gdbarch_register_name (gdbarch, regnum) == NULL
       || gdbarch_register_name (gdbarch, regnum)[0] == '\0')
     return 0;
 
-  if (reggroup == all_reggroup)
-    return 1;
-  else if (reggroup == float_reggroup)
+  if (reggroup == all_reggroup) {
+    if (regnum < RISCV_FIRST_CSR_REGNUM)
+      return 1;
+    /* Only include CSRs that have aliases. */
+    for (i = 0; i < ARRAY_SIZE (riscv_register_aliases); ++i) {
+	if (regnum == riscv_register_aliases[i].regnum)
+          return 1;
+    }
+    return 0;
+  } else if (reggroup == float_reggroup)
     return (regnum >= RISCV_FIRST_FP_REGNUM && regnum <= RISCV_LAST_FP_REGNUM)
 	    || (regnum == RISCV_CSR_FCSR_REGNUM
 	        || regnum == RISCV_CSR_FFLAGS_REGNUM
@@ -646,9 +648,16 @@ riscv_register_reggroup_p (struct gdbarch  *gdbarch,
     return regnum < RISCV_FIRST_FP_REGNUM;
   else if (reggroup == restore_reggroup || reggroup == save_reggroup)
     return regnum <= RISCV_LAST_FP_REGNUM;
-  else if (reggroup == system_reggroup)
-    return regnum >= RISCV_FIRST_CSR_REGNUM && regnum <= RISCV_LAST_CSR_REGNUM;
-  else if (reggroup == vector_reggroup)
+  else if (reggroup == system_reggroup) {
+    /* Only include CSRs that have aliases. */
+    if (regnum < RISCV_FIRST_CSR_REGNUM || regnum > RISCV_LAST_CSR_REGNUM)
+      return 0;
+    for (i = 0; i < ARRAY_SIZE (riscv_register_aliases); ++i) {
+	if (regnum == riscv_register_aliases[i].regnum)
+          return 1;
+    }
+    return 0;
+  } else if (reggroup == vector_reggroup)
     return 0;
   else
     internal_error (__FILE__, __LINE__, _("unhandled reggroup"));
@@ -1149,6 +1158,7 @@ riscv_gdbarch_init (struct gdbarch_info  info,
       const struct tdesc_feature *feature;
       struct tdesc_arch_data *tdesc_data;
       int valid_p;
+      char buf[20];
 
       feature = tdesc_find_feature (info.target_desc, "org.gnu.gdb.riscv.cpu");
       if (feature == NULL)
@@ -1157,8 +1167,14 @@ riscv_gdbarch_init (struct gdbarch_info  info,
       tdesc_data = tdesc_data_alloc ();
 
       valid_p = 1;
-      for (i = RISCV_ZERO_REGNUM; i < RISCV_LAST_REGNUM; ++i)
-	valid_p &= tdesc_numbered_register (feature, tdesc_data, i, riscv_gdb_reg_names[i]);
+      for (i = RISCV_ZERO_REGNUM; i <= RISCV_LAST_FP_REGNUM; ++i)
+        valid_p &= tdesc_numbered_register (feature, tdesc_data, i,
+            riscv_gdb_reg_names[i]);
+      for (i = RISCV_FIRST_CSR_REGNUM; i <= RISCV_LAST_CSR_REGNUM; ++i)
+        {
+          sprintf(buf, "csr%d", i - RISCV_FIRST_CSR_REGNUM);
+          valid_p &= tdesc_numbered_register (feature, tdesc_data, i, buf);
+        }
 
       if (!valid_p)
 	tdesc_data_cleanup (tdesc_data);

--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -71,17 +71,17 @@ enum {
   RISCV_FA1_REGNUM = 50,
   RISCV_LAST_FP_REGNUM = 64,	/* Last Floating Point Register */
 
-#define RISCV_FIRST_CSR_REGNUM (RISCV_LAST_FP_REGNUM + 1)
+  RISCV_FIRST_CSR_REGNUM = 65,  /* First CSR */
 #define DECLARE_CSR(name, num) RISCV_ ## num ## _REGNUM = RISCV_LAST_FP_REGNUM + 1 + num,
 #include "opcode/riscv-opc.h"
 #undef DECLARE_CSR
-#define RISCV_LAST_CSR_REGNUM (RISCV_LAST_REGNUM - 1)
+  RISCV_LAST_CSR_REGNUM = 4160,
 
   /* Leave this as the last enum.  */
-  RISCV_LAST_REGNUM = RISCV_LAST_FP_REGNUM+4097
+  RISCV_NUM_REGS
 };
 
-#define RISCV_NUM_REGS (RISCV_LAST_REGNUM)
+#define RISCV_LAST_REGNUM (RISCV_NUM_REGS - 1)
 
 /* RISC-V specific per-architecture information.  */
 struct gdbarch_tdep

--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -71,14 +71,14 @@ enum {
   RISCV_FA1_REGNUM = 50,
   RISCV_LAST_FP_REGNUM = 64,	/* Last Floating Point Register */
 
-#define RISCV_FIRST_CSR_REGNUM RISCV_LAST_FP_REGNUM + 1
-#define DECLARE_CSR(name, num) RISCV_ ## num ## _REGNUM,
+#define RISCV_FIRST_CSR_REGNUM (RISCV_LAST_FP_REGNUM + 1)
+#define DECLARE_CSR(name, num) RISCV_ ## num ## _REGNUM = RISCV_LAST_FP_REGNUM + 1 + num,
 #include "opcode/riscv-opc.h"
 #undef DECLARE_CSR
-#define RISCV_LAST_CSR_REGNUM RISCV_LAST_REGNUM - 1
+#define RISCV_LAST_CSR_REGNUM (RISCV_LAST_REGNUM - 1)
 
   /* Leave this as the last enum.  */
-  RISCV_LAST_REGNUM
+  RISCV_LAST_REGNUM = RISCV_LAST_FP_REGNUM+4097
 };
 
 #define RISCV_NUM_REGS (RISCV_LAST_REGNUM)


### PR DESCRIPTION
The reason for this change is to allow a gdb user to access arbitrary CSR registers that may be implemented on a given core. In 'info all-registers', 'info registers all', and 'info registers system' only the CSRs that have aliases defined are displayed. To keep the code simple, this change changes the register numbers gdb uses internally and when communicating to clients using its own protocol. Any existing clients will need to be modified to accommodate the new numbers.

It's also possible now to access GPRs using both their "simple name" (eg. x10) as well as their alias name (eg. a0).

This implementation doesn't use XML files, because I couldn't find the mechanism documented anywhere. I believe the new code is a strict improvement over the existing code, and doesn't make it any harder to switch to XML files at a later time.

This request is identical to https://github.com/riscv/riscv-binutils-gdb/pull/6, but its history has been cleaned up a bit.