### PR TITLE
Add support for virtual priv register.

### DIFF
--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -77,6 +77,8 @@ enum {
 #undef DECLARE_CSR
   RISCV_LAST_CSR_REGNUM = 4160,
 
+  RISCV_PRIV_REGNUM = 4161,
+
   /* Leave this as the last enum.  */
   RISCV_NUM_REGS
 };


### PR DESCRIPTION
Users can use this register to inspect and change the privilege level of
the core. It doesn't make any assumptions about the actual underlying
debug mechanism (as opposed to having the user change DCSR directly,
which may not exist in all debug implementations).