### PR TITLE
fixing compilation error with older linux env

### DIFF
--- a/sim/riscv/sim-main.c
+++ b/sim/riscv/sim-main.c
@@ -90,7 +90,12 @@ fetch_csr (SIM_CPU *cpu, const char *name, int csr, unsigned_word *reg)
       {
 	struct timespec ts;
 
+#if defined(CLOCK_BOOTTIME)
 	if (clock_gettime (CLOCK_BOOTTIME, &ts) == 0)
+#else
+	if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
+#endif
+
 	  {
 	    uint64_t time = (uint64_t)ts.tv_sec * 1000 * 1000 + ts.tv_nsec;
 	    *reg = (csr == CSR_TIME) ? time : (time >> 32);


### PR DESCRIPTION
In my environment CLOCK_BOOTTIME is missing. For this case I suggest to revert to CLOCK_MONOTONIC. 
A little poking on this topic revealed that this could be a reason for platform incompatibility. According to different forums OSX doesn't have clock_gettime (I don't use OSX so couldn't confirm), other OSes would have different enums for clock IDs. My CentOS is happy with CLOCK_MONOTONIC but perhaps worth a more robust solution, especially if someone can try on other OSes. Until then would be good to have this hack in since riscv-tools build fails without it.