### PR TITLE
Leave decr_pc_after_break at 0.

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1203,7 +1203,6 @@ riscv_gdbarch_init (struct gdbarch_info  info,
   /* Information about the target architecture.  */
   set_gdbarch_return_value (gdbarch, riscv_return_value);
   set_gdbarch_breakpoint_from_pc (gdbarch, riscv_breakpoint_from_pc);
-  set_gdbarch_decr_pc_after_break (gdbarch, 4);
   set_gdbarch_remote_breakpoint_from_pc (gdbarch, riscv_remote_breakpoint_from_pc);
   set_gdbarch_print_insn (gdbarch, print_insn_riscv);
 


### PR DESCRIPTION
It was set to 4, which tells gdb that when a breakpoint is hit the
reported PC might be 4 after the breakpoint. AFAICT this is not the case
in RISC-V, and it is certainly not the case when debugging through
OpenOCD. In fact this change causes a problem when debugging through
OpenOCD if there is a software breakpoint set at foo, and a hardware
trigger set at foo+4. When the hardware trigger is hit, gdb will
decrement the PC by 4, find the software breakpoint, and then change the
PC on the target to match the software breakpoint. It's never possible
to resume execution, and the instruction that has the software
breakpoint on it is executed every time the user tries.

I don't know how this affects native RISC-V gdb, but Palmer says: "Well,
I'd just speculate it's a GDB bug and submit the PR, ideally with a test
case of some sort.  As far as I know nobody a really runs native GDB,
but if they do then hopefully they'll speak up and we'll figure out
what's going on."