### PR TITLE
Don't use "_gp" on RISC-V, use "_global_pointer$" instead

### DIFF
--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -1463,7 +1463,7 @@ riscv_global_pointer_value (struct bfd_link_info *info)
 {
   struct bfd_link_hash_entry *h;
 
-  h = bfd_link_hash_lookup (info->hash, "_gp", FALSE, FALSE, TRUE);
+  h = bfd_link_hash_lookup (info->hash, "__global_pointer$", FALSE, FALSE, TRUE);
   if (h == NULL || h->type != bfd_link_hash_defined)
     return 0;
 

--- a/ld/emulparams/elf32lriscv-defs.sh
+++ b/ld/emulparams/elf32lriscv-defs.sh
@@ -23,7 +23,7 @@ TEXT_START_ADDR=0x10000
 MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
 COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
 
-SDATA_START_SYMBOLS="_gp = . + 0x800;
+SDATA_START_SYMBOLS="__global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)"
 
 INITIAL_READONLY_SECTIONS=".interp         : { *(.interp) } ${CREATE_PIE-${INITIAL_READONLY_SECTIONS}}"


### PR DESCRIPTION
"_gp" could conflict with ABI-complient code.  While it's probably OK
because MIPS uses this name, we figured it'd be good to clean this up
before a release with RISC-V in it.

ld/ChangeLog:

2017-02-08  Palmer Dabbelt  <palmer@dabbelt.com>

        * emulparams/elf32lriscv-defs.sh (SDATA_START_SYMBOLS): Change
        _gp to __global_pointer$.

bfd/ChangeLog:

2017-02-08  Palmer Dabbelt  <palmer@dabbelt.com>

        * elfnn-riscv.c (riscv_global_pointer_value): Change _gp to
        __global_pointer$.