### PR TITLE
Compressed breakpoint option

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -160,18 +160,6 @@ static const struct register_alias riscv_register_aliases[] =
 };
 
 static enum auto_boolean use_compressed_breakpoints;
-/*
-static void
-show_use_compressed_breakpoints (struct ui_file *file, int from_tty,
-			    struct cmd_list_element *c,
-			    const char *value)
-{
-  fprintf_filtered (file,
-		    _("Debugger's behavior regarding "
-		      "compressed breakpoints is %s.\n"),
-		    value);
-}
-*/
 
 static struct cmd_list_element *setriscvcmdlist = NULL;
 static struct cmd_list_element *showriscvcmdlist = NULL;

--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -69,13 +69,11 @@ enum {
 
 #define RISCV_LAST_REGNUM (RISCV_NUM_REGS - 1)
 
-typedef enum { SUP_UNKNOWN, SUP_YES, SUP_NO } supported_t;
-
 /* RISC-V specific per-architecture information.  */
 struct gdbarch_tdep
 {
   int riscv_abi;
-  supported_t supports_compressed_isa;
+  enum auto_boolean supports_compressed_isa;
 };
 
 static inline int


### PR DESCRIPTION
This allows people to force the gdb to use or not use compressed
breakpoints, in case misa isn't accessible to determine this
automatically. Specifically, there's a user whose core does not support
compressed instructions but misa is not where gdb expects it to be
because it was moved in the 1.9.1 privileged spec.