### PR TITLE
Check the reserved high-order bits in e_flags on RISC-V

### DIFF
--- a/bfd/ChangeLog
+++ b/bfd/ChangeLog
@@ -1,5 +1,10 @@
 2017-02-13  Palmer Dabbelt  <palmer@dabbelt.com>
 
+	* elfnn-riscv.c (_bfd_riscv_elf_merge_private_bfd_data): Check the
+	reserved bits in e_flags for ibfd and obfd.
+
+2017-02-13  Palmer Dabbelt  <palmer@dabbelt.com>
+
 	* elfnn-riscv.c (riscv_global_pointer_value): Change _gp to
 	__global_pointer$.
 

--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -2590,6 +2590,22 @@ _bfd_riscv_elf_merge_private_bfd_data (bfd *ibfd, struct bfd_link_info *info)
   if (!is_riscv_elf (ibfd) || !is_riscv_elf (obfd))
     return TRUE;
 
+  if ((new_flags & EF_RISCV_RESERVED) != 0)
+    {
+      (*_bfd_error_handler)
+        (_("%B: Unknown ELF flag `%x'"),
+	 ibfd, new_flags);
+      return FALSE;
+    }
+
+  if ((old_flags & EF_RISCV_RESERVED) != 0)
+    {
+      (*_bfd_error_handler)
+        (_("%B: Unknown ELF flag `%x'"),
+	 obfd, old_flags);
+      return FALSE;
+    }
+
   if (strcmp (bfd_get_target (ibfd), bfd_get_target (obfd)) != 0)
     {
       (*_bfd_error_handler)

--- a/include/ChangeLog
+++ b/include/ChangeLog
@@ -1,3 +1,7 @@
+2017-02-13  Palmer Dabbelt  <palmer@dabbelt.com>
+
+	* riscv.h (EF_RISCV_RESERVED): Define.
+
 2017-01-24  Dimitar Dimitrov  <dimitar@dinux.eu>
 
         * opcode/hppa.h: Clarify that file is part of GNU opcodes.

--- a/include/elf/riscv.h
+++ b/include/elf/riscv.h
@@ -109,4 +109,7 @@ END_RELOC_NUMBERS (R_RISCV_max)
 /* File uses the quad-float ABI.  */
 #define EF_RISCV_FLOAT_ABI_QUAD 0x0006
 
+/* Bits in the ELF header than must be zero. */
+#define EF_RISCV_RESERVED (~(EF_RISCV_RVC | EF_RISCV_FLOAT_ABI))
+
 #endif /* _ELF_RISCV_H */


### PR DESCRIPTION
It looks like we made one of the more embarrassing interface design
mistakes computer architects can make: not checking reserved bits.  On
RISC-V, e_flags contains ABI information that prevents users from
linking incompatible objects together.  This patch ensures the
unallocated flag bits are zero when linking, which allows us to safely
use these flags later.

bfd/ChangeLog

2017-02-13  Palmer Dabbelt  <palmer@dabbelt.com>

        * elfnn-riscv.c (_bfd_riscv_elf_merge_private_bfd_data): Check
        the reserved bits in e_flags for ibfd and obfd.

include/ChangeLog

2017-02-13  Palmer Dabbelt  <palmer@dabbelt.com>

        * riscv.h (EF_RISCV_RESERVED): Define.