### PR TITLE
Change CALL macro to use ra as the temporary address register

### DIFF
--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -147,7 +147,7 @@ const struct riscv_opcode riscv_opcodes[] =
 {"jal",       "32C", "Ca",  MATCH_C_JAL, MASK_C_JAL, match_opcode, INSN_ALIAS },
 {"jal",       "I",   "a",  MATCH_JAL | (X_RA << OP_SH_RD), MASK_JAL | MASK_RD, match_opcode, INSN_ALIAS },
 {"call",      "I",   "d,c", (X_T1 << OP_SH_RS1), (int) M_CALL,  match_never, INSN_MACRO },
-{"call",      "I",   "c", (X_T1 << OP_SH_RS1) | (X_RA << OP_SH_RD), (int) M_CALL,  match_never, INSN_MACRO },
+{"call",      "I",   "c", (X_RA << OP_SH_RS1) | (X_RA << OP_SH_RD), (int) M_CALL,  match_never, INSN_MACRO },
 {"tail",      "I",   "c", (X_T1 << OP_SH_RS1), (int) M_CALL,  match_never, INSN_MACRO },
 {"jump",      "I",   "c,s", 0, (int) M_CALL,  match_never, INSN_MACRO },
 {"nop",       "C",   "",  MATCH_C_ADDI, 0xffff, match_opcode, INSN_ALIAS },


### PR DESCRIPTION
e.g.

    1:  auipc ra, %pcrel_hi(symbol)
        jalr  ra, %pcrel_lo(1b)(ra)

The use of ra instead of t1 for address construction provides an opportunity for a microarchitecture to elide the write of the destination address, and instead read the target address as an immediate spread across the fused auipc+jalr pair. The link register ra in the jalr overwrites the target address temporary.

I've compiled the toolchain, built linux-kernel and boot tested it. Here is a snippet of objdump output after the change:

```
ffffffff80000134:	001b4097          	auipc	ra,0x1b4
ffffffff80000138:	6f6080e7          	jalr	1782(ra) # ffffffff801b482a <strcmp>
```