### PR TITLE
Add riscv_elf_ignore_reloc to pass gcc_cv_as_cfi_advance_working.

### DIFF
--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -32,6 +32,9 @@
 
 #define MINUS_ONE ((bfd_vma)0 - 1)
 
+static bfd_reloc_status_type riscv_elf_ignore_reloc
+(bfd *, arelent *, asymbol *, void *, asection *, bfd *, char **);
+
 /* The relocation table used for SHT_RELA sections.  */
 
 static reloc_howto_type howto_table[] =
@@ -480,7 +483,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_ADD8",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -495,7 +498,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_ADD16",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -510,7 +513,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_ADD32",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -525,7 +528,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_ADD64",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -540,7 +543,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SUB8",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -555,7 +558,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SUB16",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -570,7 +573,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SUB32",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -585,7 +588,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SUB64",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -767,7 +770,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SUB6",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -782,7 +785,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SET6",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -797,7 +800,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SET8",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -812,7 +815,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SET16",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -827,7 +830,7 @@ static reloc_howto_type howto_table[] =
 	 FALSE,				/* pc_relative */
 	 0,				/* bitpos */
 	 complain_overflow_dont,	/* complain_on_overflow */
-	 bfd_elf_generic_reloc,		/* special_function */
+	 riscv_elf_ignore_reloc,		/* special_function */
 	 "R_RISCV_SET32",		/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
@@ -950,4 +953,19 @@ riscv_elf_rtype_to_howto (unsigned int r_type)
       return NULL;
     }
   return &howto_table[r_type];
+}
+
+/* This function is used for relocs which are only used for relaxing,
+   which the linker should otherwise ignore.  */
+
+static bfd_reloc_status_type
+riscv_elf_ignore_reloc (bfd *abfd ATTRIBUTE_UNUSED, arelent *reloc_entry,
+		       asymbol *symbol ATTRIBUTE_UNUSED,
+		       void *data ATTRIBUTE_UNUSED, asection *input_section,
+		       bfd *output_bfd,
+		       char **error_message ATTRIBUTE_UNUSED)
+{
+  if (output_bfd != NULL)
+    reloc_entry->address += input_section->output_offset;
+  return bfd_reloc_ok;
 }


### PR DESCRIPTION
This patch is for GCC that can generate human readable cfi directive as @kito-cheng mentioned in [riscv-gcc/issues/81](https://github.com/riscv/riscv-gcc/issues/81#issuecomment-315976906).