### PR TITLE
Fix use-after free bug

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -200,7 +200,6 @@ riscv_set_arch (const char *s)
 	  extension = subset;
 	  riscv_add_subset (subset);
 	  p += strlen (subset);
-	  free (subset);
 	}
       else if (*p == '_')
 	p++;
@@ -220,6 +219,8 @@ riscv_set_arch (const char *s)
       else
 	as_fatal ("-march=%s: unsupported ISA subset `%c'", s, *p);
     }
+
+  free (extension);
 }
 
 /* Handle of the OPCODE hash table.  */


### PR DESCRIPTION
2017-07-25  Andrew Waterman  <andrew@sifive.com>

	* config/tc-riscv.c (riscv_set_arch): Obviate use-after-free.