### PR TITLE
Check ISA extension prerequisites

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -215,6 +215,15 @@ riscv_set_arch (const char *s)
 	as_fatal ("-march=%s: unsupported ISA subset `%c'", s, *p);
     }
 
+  if (riscv_subset_supports ("d") && !riscv_subset_supports ("f"))
+    as_fatal ("-march=%s: `d' extension requires `f' extension", s);
+
+  if (riscv_subset_supports ("q") && !riscv_subset_supports ("d"))
+    as_fatal ("-march=%s: `q' extension requires `d' extension", s);
+
+  if (riscv_subset_supports ("q") && xlen < 64)
+    as_fatal ("-march=%s: rv32 does not support the `q' extension", s);
+
   free (extension);
 }
 


### PR DESCRIPTION
2017-08-15  Andrew Waterman  <andrew@sifive.com>

	* config/tc-riscv.c (riscv_set_arch): Check that D and Q extensions
	meet their prerequisites.
