### PR TITLE
RISC-V: Enforce 4-byte alignment before '.option norvc'

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -2220,7 +2220,13 @@ s_riscv_option (int x ATTRIBUTE_UNUSED)
   if (strcmp (name, "rvc") == 0)
     riscv_set_rvc (TRUE);
   else if (strcmp (name, "norvc") == 0)
-    riscv_set_rvc (FALSE);
+    {
+      /* Without the C extension, RISC-V mandates 4-byte instruction alignment.
+       * Users regularly forget to align their code, so we're doing it for them
+       * here.  */
+      riscv_frag_align_code(2);
+      riscv_set_rvc (FALSE);
+    }
   else if (strcmp (name, "pic") == 0)
     riscv_opts.pic = TRUE;
   else if (strcmp (name, "nopic") == 0)


### PR DESCRIPTION
RISC-V systems without the C extension mandate 4-byte alignment.  Users
keep forgetting about this and filing bugs, so we're just going to go
ahead and enforce the alignment as part of '.option norvc'.

gas/ChangeLog

2017-11-08  Palmer Dabbelt  <palmer@sifive.com>

        * config/tc-riscv.c (s_riscv_option): Enforce 4-byte alignment
        on '.option norvc'.