### PR TITLE
Don't show registers that don't exist

### DIFF
--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -600,7 +600,6 @@ gdbarch_from_bfd (bfd *abfd)
   gdbarch_info_init (&info);
 
   info.abfd = abfd;
-  info.target_desc = target_current_description ();
   return gdbarch_find_by_info (info);
 }
 

--- a/gdb/arch-utils.c
+++ b/gdb/arch-utils.c
@@ -600,6 +600,7 @@ gdbarch_from_bfd (bfd *abfd)
   gdbarch_info_init (&info);
 
   info.abfd = abfd;
+  info.target_desc = target_current_description ();
   return gdbarch_find_by_info (info);
 }
 

--- a/gdb/gdbarch.c
+++ b/gdb/gdbarch.c
@@ -124,6 +124,19 @@ pstring_list (const char *const *list)
 
 /* Maintain the struct gdbarch object.  */
 
+/**
+ * Note that it is normal during GDB operation that several different gdbarch
+ * objects are in use, which have somewhat different contents and are used for
+ * different purposes.
+ *
+ * In particular, there are gdbarch objects that describe a *target* (i.e. an
+ * inferior GDB is operating on) -- those use target descriptions, and care
+ * about registers etc.
+ *
+ * But then there are also gdbarch objects that are used solely when looking at
+ * an *object file*, without involving any connection to a target -- those
+ * don't have target descriptions, and don't care about registers.
+ */
 struct gdbarch
 {
   /* Has this architecture been fully initialized?  */

--- a/gdb/gdbarch.h
+++ b/gdb/gdbarch.h
@@ -1646,6 +1646,12 @@ struct gdbarch_info
   const struct target_desc *target_desc;
 };
 
+/* Initialize the current architecture based on INFO.  If possible,
+   re-use an architecture from ARCHES, which is a list of
+   architectures already created during this debugging session.
+
+   Called e.g. at program startup, when reading a core file, and when
+   reading a binary file.  */
 typedef struct gdbarch *(gdbarch_init_ftype) (struct gdbarch_info info, struct gdbarch_list *arches);
 typedef void (gdbarch_dump_tdep_ftype) (struct gdbarch *gdbarch, struct ui_file *file);
 

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1244,8 +1244,6 @@ registers_init (struct gdbarch *gdbarch, struct gdbarch_info info)
           if (!success && reg_info->required)
             {
               use_tdesc_registers = false;
-              fprintf_filtered (gdb_stdout, ">>> don't use tdesc because %s is missing\n",
-                                reg_info->names[0]);
               break;
             }
         }
@@ -1309,15 +1307,6 @@ riscv_gdbarch_init (struct gdbarch_info info,
 
   int abi;
 
-  fprintf_filtered (gdb_stdout, ">>> riscv_gdbarch_init()\n");
-  fprintf_filtered (gdb_stdout, ">>>     bits_per_word=%d\n", binfo->bits_per_word);
-  fprintf_filtered (gdb_stdout, ">>>     tdesc_has_register() -> %d\n",
-                    tdesc_has_registers (info.target_desc));
-  fprintf_filtered (gdb_stdout, ">>>     info.abfd=%p\n", info.abfd);
-  if (info.abfd) {
-      fprintf_filtered (gdb_stdout, ">>>     flavour=%d\n", bfd_get_flavour (info.abfd));
-  }
-
   /* For now, base the abi on the elf class.  */
   /* Allow the ELF class to override the register size. Ideally the target
    * (OpenOCD/spike/...) would communicate the register size to gdb instead. */
@@ -1348,10 +1337,7 @@ riscv_gdbarch_init (struct gdbarch_info info,
            size <= 0 && name != riscv_reg_info[1].names.end(); ++name)
         {
           if (tdesc_unnumbered_register (feature, *name))
-            {
-              size = tdesc_register_size (feature, *name);
-              fprintf_filtered (gdb_stdout, ">>>     size of %s is %d\n", *name, size);
-            }
+            size = tdesc_register_size (feature, *name);
         }
 
       switch (size) {
@@ -1378,21 +1364,13 @@ riscv_gdbarch_init (struct gdbarch_info info,
             binfo->bits_per_word);
     }
 
-  fprintf_filtered (gdb_stdout, ">>>     abi=%d\n", abi);
-
   /* Find a candidate among the list of pre-declared architectures.  */
   for (arches = gdbarch_list_lookup_by_info (arches, &info);
        arches != NULL;
        arches = gdbarch_list_lookup_by_info (arches->next, &info))
     {
-      fprintf_filtered (gdb_stdout, ">>>     found arch with abi %d\n",
-                        gdbarch_tdep (arches->gdbarch)->riscv_abi);
       if (gdbarch_tdep (arches->gdbarch)->riscv_abi == abi)
-        {
-          fprintf_filtered (gdb_stdout, ">>>     found arch!\n");
-          registers_init (arches->gdbarch, info);
-          return arches->gdbarch;
-        }
+        return arches->gdbarch;
     }
 
   /* None found, so create a new architecture from the information provided.

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -1281,21 +1281,15 @@ riscv_gdbarch_init (struct gdbarch_info info,
 		    struct gdbarch_list *arches)
 {
   /*
-   * Note that this function gets called multiple times, for different reasons.
-   * It gets called when we connect to a debug server, and called twice when
-   * the `file` command is used. In the very last case we don't get a
-   * target_desc, even if one was provided when connecting to the target.
+   * Note that this function is called for different purposes: Some gdbarchs
+   * are used just to inspect files. Others are used to interact with a live
+   * target. gdb will create at least one of each in a typical debug session.
    */
 
   struct gdbarch_tdep *tdep;
   const struct bfd_arch_info *binfo = info.bfd_arch_info;
 
   int abi;
-
-  /* For now, base the abi on the elf class.  */
-  /* Allow the ELF class to override the register size. Ideally the target
-   * (OpenOCD/spike/...) would communicate the register size to gdb instead. */
-  abi = RISCV_ABI_FLAG_RV32I;
   if (info.abfd && bfd_get_flavour (info.abfd) == bfd_target_elf_flavour)
     {
       unsigned char eclass = elf_elfheader (info.abfd)->e_ident[EI_CLASS];

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -543,11 +543,11 @@ riscv_print_register_formatted (struct ui_file *file, struct frame_info *frame,
       if (!deprecated_frame_register_read (frame, regnum, raw_buffer))
 	{
 	  fprintf_filtered (file, "%-15s[Invalid]\n",
-			    riscv_register_name (gdbarch, regnum));
+			    gdbarch_register_name (gdbarch, regnum));
 	  return;
 	}
 
-      fprintf_filtered (file, "%-15s", riscv_register_name (gdbarch, regnum));
+      fprintf_filtered (file, "%-15s", gdbarch_register_name (gdbarch, regnum));
       if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_BIG)
 	offset = register_size (gdbarch, regnum) - register_size (gdbarch, regnum);
       else
@@ -729,7 +729,7 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
        * gdb might ask us to print a register that we don't know about, because
        * it's in the target description. That still works, because we can ask
        * gdb to give us register name and contents by number. */
-      if (NULL == riscv_register_name (gdbarch, regnum))
+      if (NULL == gdbarch_register_name (gdbarch, regnum))
         error (_("Not a valid register for the current processor type"));
       riscv_print_register_formatted (file, frame, regnum);
       return;
@@ -744,7 +744,7 @@ riscv_print_registers_info (struct gdbarch    *gdbarch,
       /* Zero never changes, so might as well hide by default.  */
       if (regnum == RISCV_ZERO_REGNUM && !all)
         continue;
-      if (riscv_register_reggroup_p(gdbarch, regnum, reggroup))
+      if (gdbarch_register_reggroup_p(gdbarch, regnum, reggroup))
         riscv_print_register_formatted (file, frame, regnum);
     }
 }


### PR DESCRIPTION
The real fix here is to use the gdbarch_ functions instead of the riscv_ ones when displaying registers. Without that, the target description isn't checked which means that (sometimes) you'd get registers showing up that aren't actually on the target.

While discovering that this was the problem, I made some changes on the way that I think are beneficial to keep:
1. Add a few comments to undocumented gdb internal structures.
2. Factor out the register initialization into its own function.