### PR TITLE
Make native gdb builds work.

### DIFF
--- a/gdb/Makefile.in
+++ b/gdb/Makefile.in
@@ -2636,6 +2636,7 @@ ALLDEPFILES = \
 	ravenscar-thread.c \
 	remote-sim.c \
 	riscv-tdep.c \
+	riscv-linux-nat.c \
 	riscv-linux-tdep.c \
 	rl78-tdep.c \
 	rs6000-lynx178-tdep.c \

--- a/gdb/configure.nat
+++ b/gdb/configure.nat
@@ -259,6 +259,10 @@ case ${gdb_host} in
 		# Host: PowerPC, running Linux
 		NATDEPFILES="${NATDEPFILES} ppc-linux-nat.o"
 		;;
+	    riscv)
+		# Host: RISC-V, running Linux
+		NATDEPFILES="${NATDEPFILES} riscv-linux-nat.o"
+		;;
 	    s390)
 		# Host: S390, running Linux
 		NATDEPFILES="${NATDEPFILES} s390-linux-nat.o"


### PR DESCRIPTION
This fixes native gdb builds.  Tested with a canadian cross build.  It links with the patch, and fails to link without the patch.  Not execution tested, as I don't have an environment for that.

This fixes issue #96.
