### PR TITLE
Fix merge error from FSF, glob means we no longer list all tests.

### DIFF
--- a/gas/testsuite/gas/riscv/riscv.exp
+++ b/gas/testsuite/gas/riscv/riscv.exp
@@ -19,15 +19,6 @@
 # MA 02110-1301, USA.
 
 if [istarget riscv*-*-*] {
-    run_dump_test "t_insns"
-    run_dump_test "c-lui-fail"
-    run_dump_test "c-addi4spn-fail"
-    run_dump_test "c-addi16sp-fail"
-    run_dump_test "satp"
-    run_dump_test "eh-relocs"
-    run_dump_test "fmv.x"
-    run_dump_test "c-lw"
-    run_dump_test "c-ld"
     run_dump_tests [lsort [glob -nocomplain $srcdir/$subdir/*.d]]
     run_list_test "align-1"
 }


### PR DESCRIPTION
Minor problem, some gas testcases are accidentally being run twice due to a merge error.
