### PR TITLE
RISC-V: Disable shared library tests for embedded elf.

### DIFF
--- a/ld/testsuite/lib/ld-lib.exp
+++ b/ld/testsuite/lib/ld-lib.exp
@@ -1823,6 +1823,7 @@ proc check_shared_lib_support { } {
 	 && ![istarget or1k*-*-*]
 	 && ![istarget pj-*-*]
 	 && ![istarget pru-*-*]
+	 && ![istarget riscv*-*-elf]
 	 && ![istarget rl78-*-*]
 	 && ![istarget rx-*-*]
 	 && ![istarget spu-*-*]


### PR DESCRIPTION
This fixes over 150 ld testsuite failures for riscv*-elf targets, by not running shared library tests on the embedded elf target that doesn't support shared libraries.  I pushed a patch upstream, but the code has changed recently upstream, so we need a different patch for our release tree.
