### PR TITLE
RISC-V: Inform the disassembler that x0 is always 0

### DIFF
--- a/gas/testsuite/gas/riscv/auipc-x0.d
+++ b/gas/testsuite/gas/riscv/auipc-x0.d
@@ -1,0 +1,11 @@
+#as: -march=rv32i
+#objdump: -dr
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <target>:
+[ 	]+0:[ 	]+00000017[ 	]+auipc[ 	]+zero,0x0
+[ 	]+4:[ 	]+00003003[ 	]+lw[ 	]+zero,0\(zero\)

--- a/gas/testsuite/gas/riscv/auipc-x0.s
+++ b/gas/testsuite/gas/riscv/auipc-x0.s
@@ -1,0 +1,3 @@
+target:
+	auipc x0, 0
+	lw x0, 0(x0)

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -99,6 +99,8 @@ arg_print (struct disassemble_info *info, unsigned long val,
 static void
 maybe_print_address (struct riscv_private_data *pd, int base_reg, int offset)
 {
+  if (base_reg == 0)
+    pd->hi_addr[base_reg] = 0;
   if (pd->hi_addr[base_reg] != (bfd_vma)-1)
     {
       pd->print_addr = pd->hi_addr[base_reg] + offset;


### PR DESCRIPTION
The RISC-V ISA defines a hardware-enforced zero register, denotated as
either x0 or zero.  Normal programs don't write to this register, but
when playing around with how our assembler interprets awkward addresses
I noticed that our disassembler doesn't know that x0 always has the
value 0.  For example, before this patch we produce the following
output:

    0000000000010078 <__bss_start-0x1008>:
       10078:	00000017          	auipc	zero,0x0
       1007c:	00003003          	ld	zero,0(zero) # 10078 <__bss_start-0x1008>

While I'm arithmatically challaged, I'm pretty sure that 0+0 isn't
0x10078.  This isn't really a problem: it's just an incorrect
disassembler hint and nobody should we writing to x0 anyway, but it's
technically wrong.

opcodes/ChangeLog

2018-01-08  Palmer Dabbelt  <palmer@dabbelt.com>

        * riscv-dis.c (maybe_print_address): x0 is always 0.

gas/ChangeLog

2018-01-08  Palmer Dabbelt  <palmer@dabbelt.com>

        * testsuite/gas/riscv/auipc-x0.d: New testcase.
        * testsuite/gas/riscv/auipc-x0.s: Likewise.