### PR TITLE
RISC-V: Patches to fix build on riscv-next branch.

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -1829,7 +1829,7 @@ md_parse_option (int c, const char *arg)
     case OPTION_MABI:
       if (strcmp (arg, "ilp32") == 0)
 	riscv_set_abi (32, FLOAT_ABI_SOFT, FALSE);
-      if (strcmp (arg, "ilp32e") == 0)
+      else if (strcmp (arg, "ilp32e") == 0)
 	riscv_set_abi (32, FLOAT_ABI_SOFT, TRUE);
       else if (strcmp (arg, "ilp32f") == 0)
 	riscv_set_abi (32, FLOAT_ABI_SINGLE, FALSE);

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -333,7 +333,7 @@ riscv_extract_return_value (struct type *type,
 			    gdb_byte *dst,
 			    int regnum)
 {
-  struct gdbarch *gdbarch = get_regcache_arch (regs);
+  struct gdbarch *gdbarch = regs->arch ();
   enum bfd_endian byte_order = gdbarch_byte_order (gdbarch);
   int regsize = riscv_isa_regsize (gdbarch);
   bfd_byte *valbuf = dst;
@@ -361,7 +361,7 @@ riscv_store_return_value (struct type *type,
 			  const gdb_byte *src,
 			  int regnum)
 {
-  struct gdbarch *gdbarch = get_regcache_arch (regs);
+  struct gdbarch *gdbarch = regs->arch ();
   int regsize = riscv_isa_regsize (gdbarch);
   const bfd_byte *valbuf = src;
 


### PR DESCRIPTION
	gas/
	* config/tc-riscv.c (md_parse_option) <OPTION_MABI>: Add missing else
	for ilp32e check.
	gdb/
	* riscv-tdep.c (riscv_extract_return_value): Use regs->arch ()
	instead of get_regcache_arch.
	(riscv_store_return_value): Likewise.