### PR TITLE
Assemble and disassemble proposed FENCE.TSO instruction

### DIFF
--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -141,6 +141,8 @@
 #define MASK_FENCE  0x707f
 #define MATCH_FENCE_I 0x100f
 #define MASK_FENCE_I  0x707f
+#define MATCH_FENCE_TSO 0x8330000f
+#define MASK_FENCE_TSO  0xfff0707f
 #define MATCH_MUL 0x2000033
 #define MASK_MUL  0xfe00707f
 #define MATCH_MULH 0x2001033

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -301,6 +301,7 @@ const struct riscv_opcode riscv_opcodes[] =
 {"fence",     "I",   "",  MATCH_FENCE | MASK_PRED | MASK_SUCC, MASK_FENCE | MASK_RD | MASK_RS1 | MASK_IMM, match_opcode, INSN_ALIAS },
 {"fence",     "I",   "P,Q",  MATCH_FENCE, MASK_FENCE | MASK_RD | MASK_RS1 | (MASK_IMM & ~MASK_PRED & ~MASK_SUCC), match_opcode, 0 },
 {"fence.i",   "I",   "",  MATCH_FENCE_I, MASK_FENCE | MASK_RD | MASK_RS1 | MASK_IMM, match_opcode, 0 },
+{"fence.tso", "I",   "",  MATCH_FENCE_TSO, MASK_FENCE_TSO | MASK_RD | MASK_RS1, match_opcode, INSN_ALIAS },
 {"rdcycle",   "I",   "d",  MATCH_RDCYCLE, MASK_RDCYCLE, match_opcode, INSN_ALIAS },
 {"rdinstret", "I",   "d",  MATCH_RDINSTRET, MASK_RDINSTRET, match_opcode, INSN_ALIAS },
 {"rdtime",    "I",   "d",  MATCH_RDTIME, MASK_RDTIME, match_opcode, INSN_ALIAS },


### PR DESCRIPTION
I'm putting this here as a placeholder rather than submitting the patch to FSF because it's still just a proposal at this point.

FENCE.TSO is analogous to Power's ```lwsync``` and is a performant mapping for ```smp_store_release``` in the Linux kernel and ```atomic_thread_fence(memory_order_acq_rel)``` in C.  It executes correctly on existing implementations because it is encoded in the subspace of FENCE RW,RW, which is strictly stronger.

cc @palmer-dabbelt @jim-wilson