### PR TITLE
Fix output for 'info registers' command.

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -578,9 +578,28 @@ riscv_print_register_formatted (struct ui_file *file, struct frame_info *frame,
 
       size = register_size (gdbarch, regnum);
       get_formatted_print_options (&opts, 'x');
+
+      char csize;
+      switch (size) {
+          case 1:
+            csize = 'b';
+            break;
+          case 2:
+            csize = 'h';
+            break;
+          case 4:
+            csize = 'w';
+            break;
+          case 8:
+            csize = 'g';
+            break;
+          default:
+            csize = 0;
+      }
+
       print_scalar_formatted (raw_buffer + offset,
 			      register_type (gdbarch, regnum), &opts,
-			      size == 8 ? 'g' : 'w', file);
+			      csize, file);
       fprintf_filtered (file, "\t");
       if (size == 4 && riscv_isa_regsize (gdbarch) == 8)
 	fprintf_filtered (file, "\t");

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -594,7 +594,7 @@ riscv_print_register_formatted (struct ui_file *file, struct frame_info *frame,
             csize = 'g';
             break;
           default:
-            csize = 0;
+            internal_error (__FILE__, __LINE__, _("unknown size for register"));
       }
 
       print_scalar_formatted (raw_buffer + offset,


### PR DESCRIPTION
Until the fix you could see output of value priv register like below:
```
(gdb) info registers priv
priv           0x01754903       prv:3 [Machine]
```
This is because the size of output is set to four bytes, but priv register contains pirvilege mode in last byte and if you want to parse hex value (e.g. in some your test case in riscv-tests/debug/gdbserver.py) you should to add workaround for getting right hex value (e.g. masking this low-byte or smth).

After fix you will be able to parsing like other registers:
```
(gdb) info registers priv
priv           0x03     prv:3 [Machine]
```