### PR TITLE
RISC-V: enable have_nonsteppable_watchpoint by default

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -172,6 +172,20 @@ struct register_alias
   int regnum;
 };
 
+static int riscv_have_nonsteppable_watchpoint = 1;
+
+/* The set callback for 'set riscv have-nonsteppable-watchpoint'. */
+
+static void
+set_have_nonsteppable_watchpoint (char *args, int from_tty,
+			       struct cmd_list_element *c)
+{
+  struct gdbarch *gdbarch = target_gdbarch ();
+
+  set_gdbarch_have_nonsteppable_watchpoint(gdbarch,
+					   riscv_have_nonsteppable_watchpoint);
+}
+
 static enum auto_boolean use_compressed_breakpoints;
 /*
 static void
@@ -1403,6 +1417,8 @@ riscv_gdbarch_init (struct gdbarch_info info,
   set_gdbarch_return_value (gdbarch, riscv_return_value);
   set_gdbarch_breakpoint_kind_from_pc (gdbarch, riscv_breakpoint_kind_from_pc);
   set_gdbarch_sw_breakpoint_from_kind (gdbarch, riscv_sw_breakpoint_from_kind);
+  set_gdbarch_have_nonsteppable_watchpoint(gdbarch,
+					   riscv_have_nonsteppable_watchpoint);
 
   /* Functions to supply register information.  */
   set_gdbarch_register_name (gdbarch, riscv_register_name);
@@ -1457,6 +1473,7 @@ _initialize_riscv_tdep (void)
       &showriscvcmdlist, "show riscv ", 0, &showlist);
 
   use_compressed_breakpoints = AUTO_BOOLEAN_AUTO;
+
   add_setshow_auto_boolean_cmd ("use_compressed_breakpoints", no_class,
       &use_compressed_breakpoints,
       _("Configure whether to use compressed breakpoints."),
@@ -1470,4 +1487,20 @@ used."),
       NULL,
       &setriscvcmdlist,
       &showriscvcmdlist);
+
+  add_setshow_boolean_cmd ("have-nonsteppable-watchpoint", no_class,
+			   &riscv_have_nonsteppable_watchpoint,
+			   _("\
+Set whether debugger must step over hardware watchpoints"),
+			   _("\
+Show whether debugger must step over hardware watchpoints"),
+			   _("\
+The RISC-V debug spec recommends that hardware write watchpoints fire before\n\
+the write is committed, in which case, GDB must step over the watchpoint\n\
+before checking the old and new values. Set this option to 1 (default) for\n\
+targets that follow this behaviour, otherwise set to 0."),
+			   set_have_nonsteppable_watchpoint,
+			   NULL,
+			   &setriscvcmdlist,
+			   &showriscvcmdlist);
 }

--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -172,9 +172,13 @@ struct register_alias
   int regnum;
 };
 
+/* Controls whether the debugger should step over hardware watchpoints before
+   checking if the watched variable has changed.  If true, then the debugger
+   will step over the watchpoint.  */
+
 static int riscv_have_nonsteppable_watchpoint = 1;
 
-/* The set callback for 'set riscv have-nonsteppable-watchpoint'. */
+/* The set callback for 'set riscv have-nonsteppable-watchpoint'.  */
 
 static void
 set_have_nonsteppable_watchpoint (char *args, int from_tty,
@@ -184,6 +188,18 @@ set_have_nonsteppable_watchpoint (char *args, int from_tty,
 
   set_gdbarch_have_nonsteppable_watchpoint(gdbarch,
 					   riscv_have_nonsteppable_watchpoint);
+}
+
+/* The show callback for 'show riscv have-nonsteppable-watchpoint'.  */
+
+static void
+show_have_nonsteppable_watchpoint (struct ui_file *file, int from_tty,
+				   struct cmd_list_element *c,
+				   const char *value)
+{
+  fprintf_filtered (file,
+		    _("Debugger must step over hardware watchpoints is set to "
+		      "%s.\n"), value);
 }
 
 static enum auto_boolean use_compressed_breakpoints;
@@ -1497,10 +1513,10 @@ Show whether debugger must step over hardware watchpoints"),
 			   _("\
 The RISC-V debug spec recommends that hardware write watchpoints fire before\n\
 the write is committed, in which case, GDB must step over the watchpoint\n\
-before checking the old and new values. Set this option to 1 (default) for\n\
-targets that follow this behaviour, otherwise set to 0."),
+before checking the old and new values.  Set this option to 'on' (default)\n\
+for targets that follow this behaviour, otherwise set to 'off'."),
 			   set_have_nonsteppable_watchpoint,
-			   NULL,
+			   show_have_nonsteppable_watchpoint,
 			   &setriscvcmdlist,
 			   &showriscvcmdlist);
 }


### PR DESCRIPTION
This is a fix for https://github.com/riscv/riscv-openocd/issues/295

The RISC-V debug spec 0.13 recommends that write triggers fire before
the write is committed. If the target follows this behaviour, then
have_nonsteppable_watchpoint needs to be set to 1 so that GDB will step
over the watchpoint before checking if the value has changed.

This patch adds a setshow for have_nonsteppable_watchpoint which defaults
to 1 to match the recommended behaviour. If a target does not follow
this timing, then 'set riscv have_nonsteppable_watchpoint 0' will need
to be issued on the command line.

Note: I will also submit a patch to upstream GDB