### PR TITLE
fix a typo in the assembler

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -2165,7 +2165,7 @@ md_assemble (char *str)
 
   if (error)
     {
-      as_bad ("%s `%s'", error, str);
+      as_bad ("%s '%s'", error, str);
       return;
     }
 


### PR DESCRIPTION
fix a typo in the error message of the assembler.