### PR TITLE
ld/ldlang: Fix linker relaxation failure if there are R_RISCV_ALIGN type relocations on RISC-V

### DIFF
--- a/ld/testsuite/ld-riscv-elf/ld-riscv-elf.exp
+++ b/ld/testsuite/ld-riscv-elf/ld-riscv-elf.exp
@@ -44,6 +44,9 @@ if [istarget "riscv*-*-*"] {
 	{ "Weak reference 64" "-T weakref.ld -melf64lriscv" ""
 	    "-march=rv64i -mabi=lp64" {weakref64.s}
 	    {{objdump -d weakref64.d}} "weakref64"}
+	{ "Linker relaxation" "-T relax.ld -melf64lriscv" ""
+	    "-march=rv64imafdc -mabi=lp64d" {relax_a.s relax_align1.s relax_align2.s relax_c.s}
+	    {} "relax"}
     }
 
     # The following tests require shared library support.

--- a/ld/testsuite/ld-riscv-elf/relax.ld
+++ b/ld/testsuite/ld-riscv-elf/relax.ld
@@ -1,0 +1,7 @@
+ENTRY(_start)
+SECTIONS {
+	.text 0x90000000 : {
+		*(.text.hot)
+		*(.text)
+	}
+}

--- a/ld/testsuite/ld-riscv-elf/relax_a.s
+++ b/ld/testsuite/ld-riscv-elf/relax_a.s
@@ -1,0 +1,9 @@
+.globl _start
+
+.section .text.hot
+_start:
+    call cc
+
+.text
+ff:
+    call dd

--- a/ld/testsuite/ld-riscv-elf/relax_align1.s
+++ b/ld/testsuite/ld-riscv-elf/relax_align1.s
@@ -1,0 +1,6 @@
+.globl align1
+
+.text
+.balign 32
+align1:
+    csrr a0, sie

--- a/ld/testsuite/ld-riscv-elf/relax_align2.s
+++ b/ld/testsuite/ld-riscv-elf/relax_align2.s
@@ -1,0 +1,7 @@
+.globl align2
+
+.text
+.balign 4
+align2:
+    csrr a0, sie
+.fill 0xfffb6

--- a/ld/testsuite/ld-riscv-elf/relax_c.s
+++ b/ld/testsuite/ld-riscv-elf/relax_c.s
@@ -1,0 +1,9 @@
+.globl cc
+.globl dd
+
+.text
+cc:
+    csrr a0, sie
+    csrr a1, sie
+dd:
+    ret


### PR DESCRIPTION
See bug report at https://sourceware.org/bugzilla/show_bug.cgi?id=25181

    ld/
        * ldlang.c (lang_size_sections_1): split the call to
          size_input_section() to 2 parts to fix linker relaxation
          failure if there are R_RISCV_ALIGN type relocations on RISC-V
        * testsuite/ld-riscv-elf/ld-riscv-elf.exp: add a test case
        * testsuite/ld-riscv-elf/relax*: the test case files