### PR TITLE
Add GAS option to disable the instruction constraints checking.

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -83,6 +83,7 @@ struct riscv_set_options
   int rve; /* Generate RVE code.  */
   int relax; /* Emit relocs the linker is allowed to relax.  */
   int arch_attr; /* Emit arch attribute.  */
+  int check_constraints; /* Enable/disable the match_func checking.  */
 };
 
 static struct riscv_set_options riscv_opts =
@@ -92,6 +93,7 @@ static struct riscv_set_options riscv_opts =
   0,	/* rve */
   1,	/* relax */
   DEFAULT_RISCV_ATTR, /* arch_attr */
+  0,	/* check_constraints */
 };
 
 static void
@@ -1648,7 +1650,8 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 	    case '\0': 	/* End of args.  */
 	      if (insn->pinfo != INSN_MACRO)
 		{
-		  if (!insn->match_func (insn, ip->insn_opcode))
+		  if (!insn->match_func (insn, ip->insn_opcode,
+					 riscv_opts.check_constraints))
 		    break;
 
 		  /* For .insn, insn->match and insn->mask are 0.  */
@@ -2531,6 +2534,8 @@ enum options
   OPTION_NO_RELAX,
   OPTION_ARCH_ATTR,
   OPTION_NO_ARCH_ATTR,
+  OPTION_CHECK_CONSTRAINTS,
+  OPTION_NO_CHECK_CONSTRAINTS,
   OPTION_END_OF_ENUM
 };
 
@@ -2545,6 +2550,8 @@ struct option md_longopts[] =
   {"mno-relax", no_argument, NULL, OPTION_NO_RELAX},
   {"march-attr", no_argument, NULL, OPTION_ARCH_ATTR},
   {"mno-arch-attr", no_argument, NULL, OPTION_NO_ARCH_ATTR},
+  {"mcheck-constraints", no_argument, NULL, OPTION_CHECK_CONSTRAINTS},
+  {"mno-check-constraints", no_argument, NULL, OPTION_NO_CHECK_CONSTRAINTS},
 
   {NULL, no_argument, NULL, 0}
 };
@@ -2621,6 +2628,14 @@ md_parse_option (int c, const char *arg)
 
     case OPTION_NO_ARCH_ATTR:
       riscv_opts.arch_attr = FALSE;
+      break;
+
+    case OPTION_CHECK_CONSTRAINTS:
+      riscv_opts.check_constraints = TRUE;
+      break;
+
+    case OPTION_NO_CHECK_CONSTRAINTS:
+      riscv_opts.check_constraints = FALSE;
       break;
 
     default:
@@ -3009,6 +3024,10 @@ s_riscv_option (int x ATTRIBUTE_UNUSED)
     riscv_opts.relax = TRUE;
   else if (strcmp (name, "norelax") == 0)
     riscv_opts.relax = FALSE;
+  else if (strcmp (name, "checkconstraints") == 0)
+    riscv_opts.check_constraints = TRUE;
+  else if (strcmp (name, "nocheckconstraints") == 0)
+    riscv_opts.check_constraints = FALSE;
   else if (strcmp (name, "push") == 0)
     {
       struct riscv_option_stack *s;

--- a/gas/testsuite/gas/riscv/vector-insns-fail-01.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-01.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-01.s
 #error_output: vector-insns-fail-01.l

--- a/gas/testsuite/gas/riscv/vector-insns-fail-02.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-02.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-02.s
 #error_output: vector-insns-fail-02.l

--- a/gas/testsuite/gas/riscv/vector-insns-fail-03.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-03.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-03.s
 #error_output: vector-insns-fail-03.l

--- a/gas/testsuite/gas/riscv/vector-insns-fail-04.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-04.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-04.s
 #error_output: vector-insns-fail-04.l

--- a/gas/testsuite/gas/riscv/vector-insns-fail-05.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-05.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-05.s
 #error_output: vector-insns-fail-05.l

--- a/gas/testsuite/gas/riscv/vector-insns-fail-06.d
+++ b/gas/testsuite/gas/riscv/vector-insns-fail-06.d
@@ -1,3 +1,3 @@
-#as: -march=rv32ifv
+#as: -march=rv32ifv -mcheck-constraints
 #source: vector-insns-fail-06.s
 #error_output: vector-insns-fail-06.l

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -395,8 +395,11 @@ struct riscv_opcode
      INSN_MACRO, then this field is the macro identifier.  */
   insn_t mask;
   /* A function to determine if a word corresponds to this instruction.
-     Usually, this computes ((word & mask) == match).  */
-  int (*match_func) (const struct riscv_opcode *op, insn_t word);
+     Usually, this computes ((word & mask) == match).  If the constraints
+     checking is disable, then most of the function should check only the
+     basic encoding for the instruction.  */
+  int (*match_func) (const struct riscv_opcode *op, insn_t word,
+		     int constraints);
   /* For a macro, this is INSN_MACRO.  Otherwise, it is a collection
      of bits describing the instruction, notably any relevant hazard
      information.  */

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -24,6 +24,7 @@
 #include "riscv-opc.h"
 #include <stdlib.h>
 #include <stdint.h>
+#include "bfd.h"
 
 typedef uint64_t insn_t;
 
@@ -398,8 +399,8 @@ struct riscv_opcode
      Usually, this computes ((word & mask) == match).  If the constraints
      checking is disable, then most of the function should check only the
      basic encoding for the instruction.  */
-  int (*match_func) (const struct riscv_opcode *op, insn_t word,
-		     int constraints);
+  bfd_boolean (*match_func) (const struct riscv_opcode *op, insn_t word,
+			     bfd_boolean constraints);
   /* For a macro, this is INSN_MACRO.  Otherwise, it is a collection
      of bits describing the instruction, notably any relevant hazard
      information.  */

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -507,7 +507,7 @@ riscv_disassemble_insn (bfd_vma memaddr, insn_t word, disassemble_info *info)
       for (; op->name; op++)
 	{
 	  /* Does the opcode match?  */
-	  if (! (op->match_func) (op, word))
+	  if (! (op->match_func) (op, word, 0))
 	    continue;
 	  /* Is this a pseudo-instruction and may we print it as such?  */
 	  if (no_aliases && (op->pinfo & INSN_ALIAS))

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -507,7 +507,7 @@ riscv_disassemble_insn (bfd_vma memaddr, insn_t word, disassemble_info *info)
       for (; op->name; op++)
 	{
 	  /* Does the opcode match?  */
-	  if (! (op->match_func) (op, word, 0))
+	  if (! (op->match_func) (op, word, FALSE))
 	    continue;
 	  /* Is this a pseudo-instruction and may we print it as such?  */
 	  if (no_aliases && (op->pinfo & INSN_ALIAS))

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -98,83 +98,106 @@ const char * const riscv_vecm_names_numeric[NVECM] =
 #define MASK_VMASK (OP_MASK_VMASK << OP_SH_VMASK)
 
 static int
-match_opcode (const struct riscv_opcode *op, insn_t insn)
+match_opcode (const struct riscv_opcode *op,
+	      insn_t insn,
+	      int constraints ATTRIBUTE_UNUSED)
 {
   return ((insn ^ op->match) & op->mask) == 0;
 }
 
 static int
 match_never (const struct riscv_opcode *op ATTRIBUTE_UNUSED,
-	     insn_t insn ATTRIBUTE_UNUSED)
+	     insn_t insn ATTRIBUTE_UNUSED,
+	     int constraints ATTRIBUTE_UNUSED)
 {
   return 0;
 }
 
 static int
-match_rs1_eq_rs2 (const struct riscv_opcode *op, insn_t insn)
+match_rs1_eq_rs2 (const struct riscv_opcode *op,
+		  insn_t insn,
+		  int constraints ATTRIBUTE_UNUSED)
 {
   int rs1 = (insn & MASK_RS1) >> OP_SH_RS1;
   int rs2 = (insn & MASK_RS2) >> OP_SH_RS2;
-  return match_opcode (op, insn) && rs1 == rs2;
+  return match_opcode (op, insn, 0) && rs1 == rs2;
 }
 
 static int
-match_vs1_eq_vs2 (const struct riscv_opcode *op, insn_t insn)
+match_vs1_eq_vs2 (const struct riscv_opcode *op,
+		  insn_t insn,
+		  int constraints ATTRIBUTE_UNUSED)
 {
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-  return match_opcode (op, insn) && vs1 == vs2;
+
+  return match_opcode (op, insn, 0) && vs1 == vs2;
 }
 
 static int
-match_vd_eq_vs1_eq_vs2 (const struct riscv_opcode *op, insn_t insn)
+match_vd_eq_vs1_eq_vs2 (const struct riscv_opcode *op,
+			insn_t insn,
+			int constraints ATTRIBUTE_UNUSED)
 {
   int vd =  (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-  return match_opcode (op, insn) && vd == vs1 && vs1 == vs2;
+
+  return match_opcode (op, insn, 0) && vd == vs1 && vs1 == vs2;
 }
 
 static int
-match_rd_nonzero (const struct riscv_opcode *op, insn_t insn)
+match_rd_nonzero (const struct riscv_opcode *op,
+		  insn_t insn,
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && ((insn & MASK_RD) != 0);
+  return match_opcode (op, insn, 0) && ((insn & MASK_RD) != 0);
 }
 
 static int
-match_c_add (const struct riscv_opcode *op, insn_t insn)
+match_c_add (const struct riscv_opcode *op,
+	     insn_t insn,
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn) && ((insn & MASK_CRS2) != 0);
+  return match_rd_nonzero (op, insn, 0) && ((insn & MASK_CRS2) != 0);
 }
 
 /* We don't allow mv zero,X to become a c.mv hint, so we need a separate
    matching function for this.  */
 
 static int
-match_c_add_with_hint (const struct riscv_opcode *op, insn_t insn)
+match_c_add_with_hint (const struct riscv_opcode *op,
+		       insn_t insn,
+		       int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && ((insn & MASK_CRS2) != 0);
+  return match_opcode (op, insn, 0) && ((insn & MASK_CRS2) != 0);
 }
 
 static int
-match_c_nop (const struct riscv_opcode *op, insn_t insn)
+match_c_nop (const struct riscv_opcode *op,
+	     insn_t insn,
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 0));
 }
 
 static int
-match_c_addi16sp (const struct riscv_opcode *op, insn_t insn)
+match_c_addi16sp (const struct riscv_opcode *op,
+		  insn_t insn,
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 2)
 	  && EXTRACT_RVC_ADDI16SP_IMM (insn) != 0);
 }
 
 static int
-match_c_lui (const struct riscv_opcode *op, insn_t insn)
+match_c_lui (const struct riscv_opcode *op,
+	     insn_t insn,
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_rd_nonzero (op, insn)
+  return (match_rd_nonzero (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
@@ -183,205 +206,261 @@ match_c_lui (const struct riscv_opcode *op, insn_t insn)
    matching function for this.  */
 
 static int
-match_c_lui_with_hint (const struct riscv_opcode *op, insn_t insn)
+match_c_lui_with_hint (const struct riscv_opcode *op,
+		       insn_t insn,
+		       int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
 
 static int
-match_c_addi4spn (const struct riscv_opcode *op, insn_t insn)
+match_c_addi4spn (const struct riscv_opcode *op,
+		  insn_t insn,
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
 }
 
 /* This requires a non-zero shift.  A zero rd is a hint, so is allowed.  */
 
 static int
-match_c_slli (const struct riscv_opcode *op, insn_t insn)
+match_c_slli (const struct riscv_opcode *op,
+	      insn_t insn,
+	      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a non-zero rd, and a non-zero shift.  */
 
 static int
-match_slli_as_c_slli (const struct riscv_opcode *op, insn_t insn)
+match_slli_as_c_slli (const struct riscv_opcode *op,
+		      insn_t insn,
+		      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_rd_nonzero (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a zero shift.  A zero rd is a hint, so is allowed.  */
 
 static int
-match_c_slli64 (const struct riscv_opcode *op, insn_t insn)
+match_c_slli64 (const struct riscv_opcode *op,
+		insn_t insn,
+		int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && EXTRACT_RVC_IMM (insn) == 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) == 0;
 }
 
 /* This is used for both srli and srai.  This requires a non-zero shift.
    A zero rd is not possible.  */
 
 static int
-match_srxi_as_c_srxi (const struct riscv_opcode *op, insn_t insn)
+match_srxi_as_c_srxi (const struct riscv_opcode *op,
+		      insn_t insn,
+		      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* These are used to check the vector constraints.  */
 
 static int
 match_widen_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
-				       insn_t insn)
+				       insn_t insn,
+				       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 2) == 0
-	  && (vs1 < vd || vs1 > (vd + 1))
-	  && (vs2 < vd || vs2 > (vd + 1))
-	  && (vm || vm < vd || vm > (vd + 1)));
+  if (constraints
+      && ((vd % 2) != 0
+	  || (vs1 >= vd && vs1 <= (vd + 1))
+	  || (vs2 >= vd && vs2 <= (vd + 1))
+	  || (!vm && vm >= vd && vm <= (vd + 1))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_widen_vd_neq_vs1_neq_vm (const struct riscv_opcode *op,
-			       insn_t insn)
+			       insn_t insn,
+			       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 2) == 0
-	  && (vs2 % 2) == 0
-	  && (vs1 < vd || vs1 > (vd + 1))
-	  && (vm || vm < vd || vm > (vd + 1)));
+  if (constraints
+      && ((vd % 2) != 0
+	  || (vs2 % 2) != 0
+	  || (vs1 >= vd && vs1 <= (vd + 1))
+	  || (!vm && vm >= vd && vm <= (vd + 1))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_widen_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
-			       insn_t insn)
+			       insn_t insn,
+			       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 2) == 0
-	  && (vs2 < vd || vs2 > (vd + 1))
-	  && (vm || vm < vd || vm > (vd + 1)));
+  if (constraints
+      && ((vd % 2) != 0
+	  || (vs2 >= vd && vs2 <= (vd + 1))
+	  || (!vm && vm >= vd && vm <= (vd + 1))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_widen_vd_neq_vm (const struct riscv_opcode *op,
-		       insn_t insn)
+		       insn_t insn,
+		       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 2) == 0
-	  && (vs2 % 2) == 0
-	  && (vm || vm < vd || vm > (vd + 1)));
+  if (constraints
+      && ((vd % 2) != 0
+	  || (vs2 % 2) != 0
+	  || (!vm && vm >= vd && vm <= (vd + 1))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_quad_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
-				      insn_t insn)
+				      insn_t insn,
+				      int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 4) == 0
-	  && (vs1 < vd || vs1 > (vd + 3))
-	  && (vs2 < vd || vs2 > (vd + 3))
-	  && (vm || vm < vd || vm > (vd + 3)));
+  if (constraints
+      && ((vd % 4) != 0
+	  || (vs1 >= vd && vs1 <= (vd + 3))
+	  || (vs2 >= vd && vs2 <= (vd + 3))
+	  || (!vm && vm >= vd && vm <= (vd + 3))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_quad_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
-			      insn_t insn)
+			      insn_t insn,
+			      int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && (vd % 4) == 0
-	  && (vs2 < vd || vs2 > (vd + 3))
-	  && (vm || vm < vd || vm > (vd + 3)));
+  if (constraints
+      && ((vd % 4) != 0
+	  || (vs2 >= vd && vs2 <= (vd + 3))
+	  || (!vm && vm >= vd && vm <= (vd + 3))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_narrow_vd_neq_vs2 (const struct riscv_opcode *op,
-			 insn_t insn)
+			 insn_t insn,
+			 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
 
-  return (match_opcode (op, insn)
-	  && (vs2 % 2) == 0
-	  && (vd < vs2 || vd > (vs2 + 1)));
+  if (constraints
+      && ((vs2 % 2) != 0
+	  || (vd >= vs2 && vd <= (vs2 + 1))))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
-				 insn_t insn)
+				 insn_t insn,
+				 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && vs1 != vd
-	  && vs2 != vd
-	  && (vm || vm != vd));
+  if (constraints
+      && (vs1 == vd
+	  || vs2 == vd
+	  || (!vm && vm == vd)))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
-			 insn_t insn)
+			 insn_t insn,
+			 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return (match_opcode (op, insn)
-	  && vs2 != vd
-	  && (vm || vm != vd));
+   if (constraints
+      && (vs2 == vd
+	  || (!vm && vm == vd)))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_vd_neq_vm (const struct riscv_opcode *op,
-		 insn_t insn)
+		 insn_t insn,
+		 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-  return match_opcode (op, insn) && (vm || vm != vd);
+  if (constraints && !vm && vm == vd)
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 static int
 match_vmv_nf_rv (const struct riscv_opcode *op,
-		 insn_t insn)
+		 insn_t insn,
+		 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
   int nf = ((insn & (0x7 << 15) ) >> 15) + 1;
 
-  return (match_opcode (op, insn)
-	  && (vd % nf) == 0
-	  && (vs2 % nf) == 0);
+  if (constraints
+      && ((vd % nf) != 0
+	  || (vs2 % nf) != 0))
+    return 0;
+
+  return match_opcode (op, insn, 0);
 }
 
 const struct riscv_opcode riscv_opcodes[] =

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -97,107 +97,105 @@ const char * const riscv_vecm_names_numeric[NVECM] =
 #define MASK_VS2 (OP_MASK_VS2 << OP_SH_VS2)
 #define MASK_VMASK (OP_MASK_VMASK << OP_SH_VMASK)
 
-static int
+static bfd_boolean
 match_opcode (const struct riscv_opcode *op,
 	      insn_t insn,
-	      int constraints ATTRIBUTE_UNUSED)
+	      bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
   return ((insn ^ op->match) & op->mask) == 0;
 }
 
-static int
+static bfd_boolean
 match_never (const struct riscv_opcode *op ATTRIBUTE_UNUSED,
 	     insn_t insn ATTRIBUTE_UNUSED,
-	     int constraints ATTRIBUTE_UNUSED)
+	     bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return 0;
+  return FALSE;
 }
 
-static int
+static bfd_boolean
 match_rs1_eq_rs2 (const struct riscv_opcode *op,
 		  insn_t insn,
-		  int constraints ATTRIBUTE_UNUSED)
+		  bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
   int rs1 = (insn & MASK_RS1) >> OP_SH_RS1;
   int rs2 = (insn & MASK_RS2) >> OP_SH_RS2;
-  return match_opcode (op, insn, 0) && rs1 == rs2;
+  return match_opcode (op, insn, FALSE) && rs1 == rs2;
 }
 
-static int
+static bfd_boolean
 match_vs1_eq_vs2 (const struct riscv_opcode *op,
 		  insn_t insn,
-		  int constraints ATTRIBUTE_UNUSED)
+		  bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-
-  return match_opcode (op, insn, 0) && vs1 == vs2;
+  return match_opcode (op, insn, FALSE) && vs1 == vs2;
 }
 
-static int
+static bfd_boolean
 match_vd_eq_vs1_eq_vs2 (const struct riscv_opcode *op,
 			insn_t insn,
-			int constraints ATTRIBUTE_UNUSED)
+			bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
   int vd =  (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-
-  return match_opcode (op, insn, 0) && vd == vs1 && vs1 == vs2;
+  return match_opcode (op, insn, FALSE) && vd == vs1 && vs1 == vs2;
 }
 
-static int
+static bfd_boolean
 match_rd_nonzero (const struct riscv_opcode *op,
 		  insn_t insn,
-		  int constraints ATTRIBUTE_UNUSED)
+		  bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && ((insn & MASK_RD) != 0);
+  return match_opcode (op, insn, FALSE) && ((insn & MASK_RD) != 0);
 }
 
-static int
+static bfd_boolean
 match_c_add (const struct riscv_opcode *op,
 	     insn_t insn,
-	     int constraints ATTRIBUTE_UNUSED)
+	     bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn, 0) && ((insn & MASK_CRS2) != 0);
+  return match_rd_nonzero (op, insn, FALSE) && ((insn & MASK_CRS2) != 0);
 }
 
 /* We don't allow mv zero,X to become a c.mv hint, so we need a separate
    matching function for this.  */
 
-static int
+static bfd_boolean
 match_c_add_with_hint (const struct riscv_opcode *op,
 		       insn_t insn,
-		       int constraints ATTRIBUTE_UNUSED)
+		       bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && ((insn & MASK_CRS2) != 0);
+  return match_opcode (op, insn, FALSE) && ((insn & MASK_CRS2) != 0);
 }
 
-static int
+static bfd_boolean
 match_c_nop (const struct riscv_opcode *op,
 	     insn_t insn,
-	     int constraints ATTRIBUTE_UNUSED)
+	     bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, 0)
+  return (match_opcode (op, insn, FALSE)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 0));
 }
 
-static int
+static bfd_boolean
 match_c_addi16sp (const struct riscv_opcode *op,
 		  insn_t insn,
-		  int constraints ATTRIBUTE_UNUSED)
+		  bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, 0)
+  return (match_opcode (op, insn, FALSE)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 2)
 	  && EXTRACT_RVC_ADDI16SP_IMM (insn) != 0);
 }
 
-static int
+static bfd_boolean
 match_c_lui (const struct riscv_opcode *op,
 	     insn_t insn,
-	     int constraints ATTRIBUTE_UNUSED)
+	     bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return (match_rd_nonzero (op, insn, 0)
+  return (match_rd_nonzero (op, insn, FALSE)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
@@ -205,71 +203,71 @@ match_c_lui (const struct riscv_opcode *op,
 /* We don't allow lui zero,X to become a c.lui hint, so we need a separate
    matching function for this.  */
 
-static int
+static bfd_boolean
 match_c_lui_with_hint (const struct riscv_opcode *op,
 		       insn_t insn,
-		       int constraints ATTRIBUTE_UNUSED)
+		       bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, 0)
+  return (match_opcode (op, insn, FALSE)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
 
-static int
+static bfd_boolean
 match_c_addi4spn (const struct riscv_opcode *op,
 		  insn_t insn,
-		  int constraints ATTRIBUTE_UNUSED)
+		  bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
+  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
 }
 
 /* This requires a non-zero shift.  A zero rd is a hint, so is allowed.  */
 
-static int
+static bfd_boolean
 match_c_slli (const struct riscv_opcode *op,
 	      insn_t insn,
-	      int constraints ATTRIBUTE_UNUSED)
+	      bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a non-zero rd, and a non-zero shift.  */
 
-static int
+static bfd_boolean
 match_slli_as_c_slli (const struct riscv_opcode *op,
 		      insn_t insn,
-		      int constraints ATTRIBUTE_UNUSED)
+		      bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_rd_nonzero (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a zero shift.  A zero rd is a hint, so is allowed.  */
 
-static int
+static bfd_boolean
 match_c_slli64 (const struct riscv_opcode *op,
 		insn_t insn,
-		int constraints ATTRIBUTE_UNUSED)
+		bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) == 0;
+  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) == 0;
 }
 
 /* This is used for both srli and srai.  This requires a non-zero shift.
    A zero rd is not possible.  */
 
-static int
+static bfd_boolean
 match_srxi_as_c_srxi (const struct riscv_opcode *op,
 		      insn_t insn,
-		      int constraints ATTRIBUTE_UNUSED)
+		      bfd_boolean constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* These are used to check the vector constraints.  */
 
-static int
+static bfd_boolean
 match_widen_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				       insn_t insn,
-				       int constraints)
+				       bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -281,15 +279,15 @@ match_widen_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 	  || (vs1 >= vd && vs1 <= (vd + 1))
 	  || (vs2 >= vd && vs2 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_widen_vd_neq_vs1_neq_vm (const struct riscv_opcode *op,
 			       insn_t insn,
-			       int constraints)
+			       bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -301,15 +299,15 @@ match_widen_vd_neq_vs1_neq_vm (const struct riscv_opcode *op,
 	  || (vs2 % 2) != 0
 	  || (vs1 >= vd && vs1 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_widen_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			       insn_t insn,
-			       int constraints)
+			       bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -319,15 +317,15 @@ match_widen_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && ((vd % 2) != 0
 	  || (vs2 >= vd && vs2 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_widen_vd_neq_vm (const struct riscv_opcode *op,
 		       insn_t insn,
-		       int constraints)
+		       bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -337,15 +335,15 @@ match_widen_vd_neq_vm (const struct riscv_opcode *op,
       && ((vd % 2) != 0
 	  || (vs2 % 2) != 0
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_quad_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				      insn_t insn,
-				      int constraints)
+				      bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -357,15 +355,15 @@ match_quad_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 	  || (vs1 >= vd && vs1 <= (vd + 3))
 	  || (vs2 >= vd && vs2 <= (vd + 3))
 	  || (!vm && vm >= vd && vm <= (vd + 3))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_quad_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			      insn_t insn,
-			      int constraints)
+			      bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -375,15 +373,15 @@ match_quad_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && ((vd % 4) != 0
 	  || (vs2 >= vd && vs2 <= (vd + 3))
 	  || (!vm && vm >= vd && vm <= (vd + 3))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_narrow_vd_neq_vs2 (const struct riscv_opcode *op,
 			 insn_t insn,
-			 int constraints)
+			 bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -391,15 +389,15 @@ match_narrow_vd_neq_vs2 (const struct riscv_opcode *op,
   if (constraints
       && ((vs2 % 2) != 0
 	  || (vd >= vs2 && vd <= (vs2 + 1))))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				 insn_t insn,
-				 int constraints)
+				 bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -410,15 +408,15 @@ match_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && (vs1 == vd
 	  || vs2 == vd
 	  || (!vm && vm == vd)))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			 insn_t insn,
-			 int constraints)
+			 bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -427,29 +425,29 @@ match_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
    if (constraints
       && (vs2 == vd
 	  || (!vm && vm == vd)))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_vd_neq_vm (const struct riscv_opcode *op,
 		 insn_t insn,
-		 int constraints)
+		 bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
   if (constraints && !vm && vm == vd)
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
-static int
+static bfd_boolean
 match_vmv_nf_rv (const struct riscv_opcode *op,
 		 insn_t insn,
-		 int constraints)
+		 bfd_boolean constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -458,9 +456,9 @@ match_vmv_nf_rv (const struct riscv_opcode *op,
   if (constraints
       && ((vd % nf) != 0
 	  || (vs2 % nf) != 0))
-    return 0;
+    return FALSE;
 
-  return match_opcode (op, insn, 0);
+  return match_opcode (op, insn, FALSE);
 }
 
 const struct riscv_opcode riscv_opcodes[] =


### PR DESCRIPTION
I get the request recently that the assembler's constraints checking break hardware exception test cases.  As I know, stop to assemble instructions with constraints is reasonable to me.  But it is hard to check whether the hardware  exceptions work expected for the constraints.  For now, the compromises are use the hard cored instruction (.word or .2byte) and .insn directives to build the test cases.  But I think the current test cases won't built by them and can not check the exception for constraints.

It seems quite easy to resolve the problem by adding a GAS internal option to disable checking the RVV constraints (always call `match_opcde` to check).  But for the normal ISA (scalar), we have much complex parsing method for the constraints (The same opcode name with different operands, Co and Cj, ...).  It doesn't make sense to me that we can use a internal option to affect the current operand parsing.  Also, add a internal option just used to disable the RVV constraints is hard to maintain.

My personal opinion is not to support a internal option used to disable the constraints.  But I can not convince them to use the hard-cored instruction and .insn directive to build the test cases in the sort-term.  Since the former is hard to be generated automatically, and the later for RVV isn't complete now (the RVV instruction name are still discussed).

Ideally, I suppose our assembler shouldn't allow to generate the instruction with constraints.  The internal usage option is also hard to maintain.  It would be great if the constraint test cases can be built by the .insn directives.  I hope we can have the leeway that not to support the internal usage option, which just for testing, in the long-term.  But in the sort-term,  it is understandable that the internal option is easy to develop (build the test cases).