### PR TITLE
Change the expansions and conversion for pseudo vector compare instructions (integer and scale).

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -1279,7 +1279,7 @@ vector_macro (struct riscv_cl_insn *ip)
 	{
 	  /* Unmasked.  */
 	  macro_build (NULL, "vmslt.vx", "Vd,Vt,sVm", vd, vs2, vs1, -1);
-	  macro_build (NULL, "vmnand.mm", "Vd,Vt,Vs", vd, vs2, vs1);
+	  macro_build (NULL, "vmnand.mm", "Vd,Vt,Vs", vd, vd, vd);
 	}
       else
 	{
@@ -1304,7 +1304,7 @@ vector_macro (struct riscv_cl_insn *ip)
 	{
 	  /* Unmasked.  */
 	  macro_build (NULL, "vmsltu.vx", "Vd,Vt,sVm", vd, vs2, vs1, -1);
-	  macro_build (NULL, "vmnand.mm", "Vd,Vt,Vs", vd, vs2, vs1);
+	  macro_build (NULL, "vmnand.mm", "Vd,Vt,Vs", vd, vd, vd);
 	}
       else
 	{

--- a/gas/testsuite/gas/riscv/v-zero-imm.d
+++ b/gas/testsuite/gas/riscv/v-zero-imm.d
@@ -1,0 +1,17 @@
+#as: -march=rv32ifv
+#objdump: -dr
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <.text>:
+[ 	]+[0-9a-f]+:[ 	]+768fb257[ 	]+vmsle.vi[ 	]+v4,v8,-1
+[ 	]+[0-9a-f]+:[ 	]+748fb257[ 	]+vmsle.vi[ 	]+v4,v8,-1,v0.t
+[ 	]+[0-9a-f]+:[ 	]+66840257[ 	]+vmsne.vv[ 	]+v4,v8,v8
+[ 	]+[0-9a-f]+:[ 	]+64840257[ 	]+vmsne.vv[ 	]+v4,v8,v8,v0.t
+[ 	]+[0-9a-f]+:[ 	]+7e8fb257[ 	]+vmsgt.vi[ 	]+v4,v8,-1
+[ 	]+[0-9a-f]+:[ 	]+7c8fb257[ 	]+vmsgt.vi[ 	]+v4,v8,-1,v0.t
+[ 	]+[0-9a-f]+:[ 	]+62840257[ 	]+vmseq.vv[ 	]+v4,v8,v8
+[ 	]+[0-9a-f]+:[ 	]+60840257[ 	]+vmseq.vv[ 	]+v4,v8,v8,v0.t

--- a/gas/testsuite/gas/riscv/v-zero-imm.s
+++ b/gas/testsuite/gas/riscv/v-zero-imm.s
@@ -1,0 +1,8 @@
+	vmslt.vi v4, v8, 0
+	vmslt.vi v4, v8, 0, v0.t
+	vmsltu.vi v4, v8, 0
+	vmsltu.vi v4, v8, 0, v0.t
+	vmsge.vi v4, v8, 0
+	vmsge.vi v4, v8, 0, v0.t
+	vmsgeu.vi v4, v8, 0
+	vmsgeu.vi v4, v8, 0, v0.t

--- a/gas/testsuite/gas/riscv/vector-insns.d
+++ b/gas/testsuite/gas/riscv/vector-insns.d
@@ -604,9 +604,9 @@ Disassembly of section .text:
 [ 	]+[0-9a-f]+:[ 	]+7887b257[ 	]+vmsgtu.vi[ 	]+v4,v8,15,v0.t
 [ 	]+[0-9a-f]+:[ 	]+78883257[ 	]+vmsgtu.vi[ 	]+v4,v8,-16,v0.t
 [ 	]+[0-9a-f]+:[ 	]+6e85c257[ 	]+vmslt.vx[ 	]+v4,v8,a1
-[ 	]+[0-9a-f]+:[ 	]+7685a257[ 	]+vmnand.mm[ 	]+v4,v8,v11
+[ 	]+[0-9a-f]+:[ 	]+76422257[ 	]+vmnot.m[ 	]+v4,v4
 [ 	]+[0-9a-f]+:[ 	]+6a85c257[ 	]+vmsltu.vx[ 	]+v4,v8,a1
-[ 	]+[0-9a-f]+:[ 	]+7685a257[ 	]+vmnand.mm[ 	]+v4,v8,v11
+[ 	]+[0-9a-f]+:[ 	]+76422257[ 	]+vmnot.m[ 	]+v4,v4
 [ 	]+[0-9a-f]+:[ 	]+6cc64457[ 	]+vmslt.vx[ 	]+v8,v12,a2,v0.t
 [ 	]+[0-9a-f]+:[ 	]+6e802457[ 	]+vmxor.mm[ 	]+v8,v8,v0
 [ 	]+[0-9a-f]+:[ 	]+68c64457[ 	]+vmsltu.vx[ 	]+v8,v12,a2,v0.t

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -1259,8 +1259,10 @@ const struct riscv_opcode riscv_opcodes[] =
 {"vmsge.vv",   0, INSN_CLASS_V,  "Vd,Vs,VtVm", MATCH_VMSLEVV, MASK_VMSLEVV, match_opcode, INSN_ALIAS },
 {"vmsgeu.vv",  0, INSN_CLASS_V,  "Vd,Vs,VtVm", MATCH_VMSLEUVV, MASK_VMSLEUVV, match_opcode, INSN_ALIAS },
 {"vmslt.vi",   0, INSN_CLASS_V,  "Vd,Vt,VkVm", MATCH_VMSLEVI, MASK_VMSLEVI, match_opcode, INSN_ALIAS },
+{"vmsltu.vi",  0, INSN_CLASS_V,  "Vd,Vu,0Vm", MATCH_VMSNEVV, MASK_VMSNEVV, match_opcode, INSN_ALIAS },
 {"vmsltu.vi",  0, INSN_CLASS_V,  "Vd,Vt,VkVm", MATCH_VMSLEUVI, MASK_VMSLEUVI, match_opcode, INSN_ALIAS },
 {"vmsge.vi",   0, INSN_CLASS_V,  "Vd,Vt,VkVm", MATCH_VMSGTVI, MASK_VMSGTVI, match_opcode, INSN_ALIAS },
+{"vmsgeu.vi",  0, INSN_CLASS_V,  "Vd,Vu,0Vm", MATCH_VMSEQVV, MASK_VMSEQVV, match_opcode, INSN_ALIAS },
 {"vmsgeu.vi",  0, INSN_CLASS_V,  "Vd,Vt,VkVm", MATCH_VMSGTUVI, MASK_VMSGTUVI, match_opcode, INSN_ALIAS },
 
 {"vmsge.vx",   0, INSN_CLASS_V, "Vd,Vt,sVm", 0, (int) M_VMSGE, match_never, INSN_MACRO },


### PR DESCRIPTION
There are two issues about the vector compare instructions recently,

1. Convert the pseudo vmsltu.vi/vmsgeu.vi to vmsne.vv/vmseq.vv, when imm is zero. 
(https://github.com/riscv/riscv-binutils-gdb/issues/206)

We convert the pseudo instructions

	`vmsltu.vi/vmsgeu.vi  vd, vs1, imm`

to

	(imm isn't zero) `vmsleu.vi/vmsgtu.vi  vd, vs1, imm - 1`
	(imm is zero)    `vmsne.vv/vmseq.vv    vd, vs1, vs1`


2. Change the expansion for vmsge.vx and vmsgeu.vx with the unmasked va.
(https://github.com/riscv/riscv-binutils-gdb/issues/208)

`vmsge[u].vx v4, v8, a1` should be expanded to `vmslt[u].vx  v4,v8,a1` plus `vmnot.m  v4,v4`.