### PR TITLE
Updated vmmv.m from vmcpy.m.

### DIFF
--- a/gas/testsuite/gas/riscv/vector-insns.d
+++ b/gas/testsuite/gas/riscv/vector-insns.d
@@ -2312,7 +2312,8 @@ Disassembly of section .text:
 [ 	]+[0-9a-f]+:[ 	]+c6861257[ 	]+vfwredsum.vs[ 	]+v4,v8,v12
 [ 	]+[0-9a-f]+:[ 	]+cc861257[ 	]+vfwredosum.vs[ 	]+v4,v8,v12,v0.t
 [ 	]+[0-9a-f]+:[ 	]+c4861257[ 	]+vfwredsum.vs[ 	]+v4,v8,v12,v0.t
-[ 	]+[0-9a-f]+:[ 	]+66842257[ 	]+vmcpy.m[ 	]+v4,v8
+[ 	]+[0-9a-f]+:[ 	]+66842257[ 	]+vmmv.m[ 	]+v4,v8
+[ 	]+[0-9a-f]+:[ 	]+66842257[ 	]+vmmv.m[ 	]+v4,v8
 [ 	]+[0-9a-f]+:[ 	]+6e422257[ 	]+vmclr.m[ 	]+v4
 [ 	]+[0-9a-f]+:[ 	]+7e422257[ 	]+vmset.m[ 	]+v4
 [ 	]+[0-9a-f]+:[ 	]+76842257[ 	]+vmnot.m[ 	]+v4,v8

--- a/gas/testsuite/gas/riscv/vector-insns.s
+++ b/gas/testsuite/gas/riscv/vector-insns.s
@@ -2636,6 +2636,7 @@
 
 	# Aliases
 	vmcpy.m v4, v8
+	vmmv.m v4, v8
 	vmclr.m v4
 	vmset.m v4
 	vmnot.m v4, v8

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -1951,6 +1951,7 @@ const struct riscv_opcode riscv_opcodes[] =
 {"vfwredosum.vs",0, INSN_CLASS_V_AND_F, "Vd,Vt,VsVm", MATCH_VFWREDOSUMV, MASK_VFWREDOSUMV, match_opcode, 0},
 {"vfwredsum.vs", 0, INSN_CLASS_V_AND_F, "Vd,Vt,VsVm", MATCH_VFWREDSUMV, MASK_VFWREDSUMV, match_opcode, 0},
 
+{"vmmv.m",     0, INSN_CLASS_V, "Vd,Vu", MATCH_VMANDMM, MASK_VMANDMM, match_vs1_eq_vs2, INSN_ALIAS},
 {"vmcpy.m",    0, INSN_CLASS_V, "Vd,Vu", MATCH_VMANDMM, MASK_VMANDMM, match_vs1_eq_vs2, INSN_ALIAS},
 {"vmclr.m",    0, INSN_CLASS_V, "Vv", MATCH_VMXORMM, MASK_VMXORMM, match_vd_eq_vs1_eq_vs2, INSN_ALIAS},
 {"vmset.m",    0, INSN_CLASS_V, "Vv", MATCH_VMXNORMM, MASK_VMXNORMM, match_vd_eq_vs1_eq_vs2, INSN_ALIAS},


### PR DESCRIPTION
Add new vmmv.m, and keep the old vmcpy.m for the compatibility.  But objdump will show the new one.

I'm updating vector vm constraints since the mask rule is changed recently.  I will adding the 0.9 release tag when I finish them.  But this PR needs to be merged first, since newest vtg and spike will be released today.

Thanks
Nelson