### PR TITLE
Revert "Change the return type of `match_func` and `constraints` flag to `bfd_boolean`."

### DIFF
--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -24,7 +24,6 @@
 #include "riscv-opc.h"
 #include <stdlib.h>
 #include <stdint.h>
-#include "bfd.h"
 
 typedef uint64_t insn_t;
 
@@ -426,8 +425,8 @@ struct riscv_opcode
      Usually, this computes ((word & mask) == match).  If the constraints
      checking is disable, then most of the function should check only the
      basic encoding for the instruction.  */
-  bfd_boolean (*match_func) (const struct riscv_opcode *op, insn_t word,
-			     bfd_boolean constraints);
+  int (*match_func) (const struct riscv_opcode *op, insn_t word,
+		     int constraints);
   /* For a macro, this is INSN_MACRO.  Otherwise, it is a collection
      of bits describing the instruction, notably any relevant hazard
      information.  */

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -512,7 +512,7 @@ riscv_disassemble_insn (bfd_vma memaddr, insn_t word, disassemble_info *info)
       for (; op->name; op++)
 	{
 	  /* Does the opcode match?  */
-	  if (! (op->match_func) (op, word, FALSE))
+	  if (! (op->match_func) (op, word, 0))
 	    continue;
 	  /* Is this a pseudo-instruction and may we print it as such?  */
 	  if (no_aliases && (op->pinfo & INSN_ALIAS))

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -97,105 +97,107 @@ const char * const riscv_vecm_names_numeric[NVECM] =
 #define MASK_VS2 (OP_MASK_VS2 << OP_SH_VS2)
 #define MASK_VMASK (OP_MASK_VMASK << OP_SH_VMASK)
 
-static bfd_boolean
+static int
 match_opcode (const struct riscv_opcode *op,
 	      insn_t insn,
-	      bfd_boolean constraints ATTRIBUTE_UNUSED)
+	      int constraints ATTRIBUTE_UNUSED)
 {
   return ((insn ^ op->match) & op->mask) == 0;
 }
 
-static bfd_boolean
+static int
 match_never (const struct riscv_opcode *op ATTRIBUTE_UNUSED,
 	     insn_t insn ATTRIBUTE_UNUSED,
-	     bfd_boolean constraints ATTRIBUTE_UNUSED)
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return FALSE;
+  return 0;
 }
 
-static bfd_boolean
+static int
 match_rs1_eq_rs2 (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints ATTRIBUTE_UNUSED)
+		  int constraints ATTRIBUTE_UNUSED)
 {
   int rs1 = (insn & MASK_RS1) >> OP_SH_RS1;
   int rs2 = (insn & MASK_RS2) >> OP_SH_RS2;
-  return match_opcode (op, insn, FALSE) && rs1 == rs2;
+  return match_opcode (op, insn, 0) && rs1 == rs2;
 }
 
-static bfd_boolean
+static int
 match_vs1_eq_vs2 (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints ATTRIBUTE_UNUSED)
+		  int constraints ATTRIBUTE_UNUSED)
 {
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-  return match_opcode (op, insn, FALSE) && vs1 == vs2;
+
+  return match_opcode (op, insn, 0) && vs1 == vs2;
 }
 
-static bfd_boolean
+static int
 match_vd_eq_vs1_eq_vs2 (const struct riscv_opcode *op,
 			insn_t insn,
-			bfd_boolean constraints ATTRIBUTE_UNUSED)
+			int constraints ATTRIBUTE_UNUSED)
 {
   int vd =  (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
-  return match_opcode (op, insn, FALSE) && vd == vs1 && vs1 == vs2;
+
+  return match_opcode (op, insn, 0) && vd == vs1 && vs1 == vs2;
 }
 
-static bfd_boolean
+static int
 match_rd_nonzero (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints ATTRIBUTE_UNUSED)
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && ((insn & MASK_RD) != 0);
+  return match_opcode (op, insn, 0) && ((insn & MASK_RD) != 0);
 }
 
-static bfd_boolean
+static int
 match_c_add (const struct riscv_opcode *op,
 	     insn_t insn,
-	     bfd_boolean constraints ATTRIBUTE_UNUSED)
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn, FALSE) && ((insn & MASK_CRS2) != 0);
+  return match_rd_nonzero (op, insn, 0) && ((insn & MASK_CRS2) != 0);
 }
 
 /* We don't allow mv zero,X to become a c.mv hint, so we need a separate
    matching function for this.  */
 
-static bfd_boolean
+static int
 match_c_add_with_hint (const struct riscv_opcode *op,
 		       insn_t insn,
-		       bfd_boolean constraints ATTRIBUTE_UNUSED)
+		       int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && ((insn & MASK_CRS2) != 0);
+  return match_opcode (op, insn, 0) && ((insn & MASK_CRS2) != 0);
 }
 
-static bfd_boolean
+static int
 match_c_nop (const struct riscv_opcode *op,
 	     insn_t insn,
-	     bfd_boolean constraints ATTRIBUTE_UNUSED)
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, FALSE)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 0));
 }
 
-static bfd_boolean
+static int
 match_c_addi16sp (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints ATTRIBUTE_UNUSED)
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, FALSE)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) == 2)
 	  && EXTRACT_RVC_ADDI16SP_IMM (insn) != 0);
 }
 
-static bfd_boolean
+static int
 match_c_lui (const struct riscv_opcode *op,
 	     insn_t insn,
-	     bfd_boolean constraints ATTRIBUTE_UNUSED)
+	     int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_rd_nonzero (op, insn, FALSE)
+  return (match_rd_nonzero (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
@@ -203,71 +205,71 @@ match_c_lui (const struct riscv_opcode *op,
 /* We don't allow lui zero,X to become a c.lui hint, so we need a separate
    matching function for this.  */
 
-static bfd_boolean
+static int
 match_c_lui_with_hint (const struct riscv_opcode *op,
 		       insn_t insn,
-		       bfd_boolean constraints ATTRIBUTE_UNUSED)
+		       int constraints ATTRIBUTE_UNUSED)
 {
-  return (match_opcode (op, insn, FALSE)
+  return (match_opcode (op, insn, 0)
 	  && (((insn & MASK_RD) >> OP_SH_RD) != 2)
 	  && EXTRACT_RVC_LUI_IMM (insn) != 0);
 }
 
-static bfd_boolean
+static int
 match_c_addi4spn (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints ATTRIBUTE_UNUSED)
+		  int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_ADDI4SPN_IMM (insn) != 0;
 }
 
 /* This requires a non-zero shift.  A zero rd is a hint, so is allowed.  */
 
-static bfd_boolean
+static int
 match_c_slli (const struct riscv_opcode *op,
 	      insn_t insn,
-	      bfd_boolean constraints ATTRIBUTE_UNUSED)
+	      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a non-zero rd, and a non-zero shift.  */
 
-static bfd_boolean
+static int
 match_slli_as_c_slli (const struct riscv_opcode *op,
 		      insn_t insn,
-		      bfd_boolean constraints ATTRIBUTE_UNUSED)
+		      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_rd_nonzero (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_rd_nonzero (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* This requires a zero shift.  A zero rd is a hint, so is allowed.  */
 
-static bfd_boolean
+static int
 match_c_slli64 (const struct riscv_opcode *op,
 		insn_t insn,
-		bfd_boolean constraints ATTRIBUTE_UNUSED)
+		int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) == 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) == 0;
 }
 
 /* This is used for both srli and srai.  This requires a non-zero shift.
    A zero rd is not possible.  */
 
-static bfd_boolean
+static int
 match_srxi_as_c_srxi (const struct riscv_opcode *op,
 		      insn_t insn,
-		      bfd_boolean constraints ATTRIBUTE_UNUSED)
+		      int constraints ATTRIBUTE_UNUSED)
 {
-  return match_opcode (op, insn, FALSE) && EXTRACT_RVC_IMM (insn) != 0;
+  return match_opcode (op, insn, 0) && EXTRACT_RVC_IMM (insn) != 0;
 }
 
 /* These are used to check the vector constraints.  */
 
-static bfd_boolean
+static int
 match_widen_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				       insn_t insn,
-				       bfd_boolean constraints)
+				       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -279,15 +281,15 @@ match_widen_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 	  || (vs1 >= vd && vs1 <= (vd + 1))
 	  || (vs2 >= vd && vs2 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_widen_vd_neq_vs1_neq_vm (const struct riscv_opcode *op,
 			       insn_t insn,
-			       bfd_boolean constraints)
+			       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -299,15 +301,15 @@ match_widen_vd_neq_vs1_neq_vm (const struct riscv_opcode *op,
 	  || (vs2 % 2) != 0
 	  || (vs1 >= vd && vs1 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_widen_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			       insn_t insn,
-			       bfd_boolean constraints)
+			       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -317,15 +319,15 @@ match_widen_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && ((vd % 2) != 0
 	  || (vs2 >= vd && vs2 <= (vd + 1))
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_widen_vd_neq_vm (const struct riscv_opcode *op,
 		       insn_t insn,
-		       bfd_boolean constraints)
+		       int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -335,15 +337,15 @@ match_widen_vd_neq_vm (const struct riscv_opcode *op,
       && ((vd % 2) != 0
 	  || (vs2 % 2) != 0
 	  || (!vm && vm >= vd && vm <= (vd + 1))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_quad_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				      insn_t insn,
-				      bfd_boolean constraints)
+				      int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -355,15 +357,15 @@ match_quad_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 	  || (vs1 >= vd && vs1 <= (vd + 3))
 	  || (vs2 >= vd && vs2 <= (vd + 3))
 	  || (!vm && vm >= vd && vm <= (vd + 3))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_quad_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			      insn_t insn,
-			      bfd_boolean constraints)
+			      int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -373,15 +375,15 @@ match_quad_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && ((vd % 4) != 0
 	  || (vs2 >= vd && vs2 <= (vd + 3))
 	  || (!vm && vm >= vd && vm <= (vd + 3))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_narrow_vd_neq_vs2 (const struct riscv_opcode *op,
 			 insn_t insn,
-			 bfd_boolean constraints)
+			 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -389,15 +391,15 @@ match_narrow_vd_neq_vs2 (const struct riscv_opcode *op,
   if (constraints
       && ((vs2 % 2) != 0
 	  || (vd >= vs2 && vd <= (vs2 + 1))))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
 				 insn_t insn,
-				 bfd_boolean constraints)
+				 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs1 = (insn & MASK_VS1) >> OP_SH_VS1;
@@ -408,15 +410,15 @@ match_vd_neq_vs1_neq_vs2_neq_vm (const struct riscv_opcode *op,
       && (vs1 == vd
 	  || vs2 == vd
 	  || (!vm && vm == vd)))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
 			 insn_t insn,
-			 bfd_boolean constraints)
+			 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -425,43 +427,43 @@ match_vd_neq_vs2_neq_vm (const struct riscv_opcode *op,
    if (constraints
       && (vs2 == vd
 	  || (!vm && vm == vd)))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_vd_neq_vs2 (const struct riscv_opcode *op,
 		  insn_t insn,
-		  bfd_boolean constraints)
+		  int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
 
    if (constraints && vs2 == vd)
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_vd_neq_vm (const struct riscv_opcode *op,
 		 insn_t insn,
-		 bfd_boolean constraints)
+		 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vm = (insn & MASK_VMASK) >> OP_SH_VMASK;
 
-   if (constraints && !vm && vm == vd)
-    return FALSE;
+  if (constraints && !vm && vm == vd)
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
-static bfd_boolean
+static int
 match_vmv_nf_rv (const struct riscv_opcode *op,
 		 insn_t insn,
-		 bfd_boolean constraints)
+		 int constraints)
 {
   int vd = (insn & MASK_VD) >> OP_SH_VD;
   int vs2 = (insn & MASK_VS2) >> OP_SH_VS2;
@@ -470,9 +472,9 @@ match_vmv_nf_rv (const struct riscv_opcode *op,
   if (constraints
       && ((vd % nf) != 0
 	  || (vs2 % nf) != 0))
-    return FALSE;
+    return 0;
 
-  return match_opcode (op, insn, FALSE);
+  return match_opcode (op, insn, 0);
 }
 
 const struct riscv_opcode riscv_opcodes[] =


### PR DESCRIPTION
This reverts commit 9d02802920483d07aee78c375f20ec24c2e1f591.

The original report is as follows,
https://sourceware.org/pipermail/binutils/2020-June/111383.html

And I have sent a patch to fix this on upstream,
https://sourceware.org/pipermail/binutils/2020-June/111405.html

Inlcude the bfd.h in the include/opcode/riscv.h may cause gdbserver fail to build.  I just want to use the `bfd_boolean` in the opcodes/riscv-opc.c, but I didn't realize this cause the build failed.  Revert the commit 9d02802920483d07aee78c375f20ec24c2e1f591 should fix the gdbserver build.

As I know we don't support vector in GDB for now, so this should be fine.  But in case we need to merge the rvv implementation into FSF binutils someday and forgot this issue, revert the commit 9d02802920483d07aee78c375f20ec24c2e1f591 now seems more safe.