### PR TITLE
RISC-V: Convert CSR dwarf numbers to gdb register numbers.

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -3150,6 +3150,9 @@ riscv_dwarf_reg_to_regnum (struct gdbarch *gdbarch, int reg)
   else if (reg < RISCV_DWARF_REGNUM_F31)
     return RISCV_FIRST_FP_REGNUM + (reg - RISCV_DWARF_REGNUM_F0);
 
+  else if (RISCV_DWARF_REGNUM_CSR_BEGIN <= reg && reg <= RISCV_DWARF_REGNUM_CSR_END)
+    return RISCV_FIRST_CSR_REGNUM + (reg - RISCV_DWARF_REGNUM_CSR_BEGIN);
+
   return -1;
 }
 

--- a/gdb/riscv-tdep.h
+++ b/gdb/riscv-tdep.h
@@ -63,6 +63,8 @@ enum
   RISCV_DWARF_REGNUM_X31 = 31,
   RISCV_DWARF_REGNUM_F0 = 32,
   RISCV_DWARF_REGNUM_F31 = 63,
+  RISCV_DWARF_REGNUM_CSR_BEGIN = 4096,
+  RISCV_DWARF_REGNUM_CSR_END = 8191,
 };
 
 /* RISC-V specific per-architecture information.  */


### PR DESCRIPTION
Debugger needs to access vector CSR registers vl and vlenb when debugging vector programs. So, gdb needs to be able to convert DWARF numbers of CSR to internal register numbers.