### PR TITLE
RISC-V: Support pause instruction as a hint fence w,0.

### DIFF
--- a/gas/testsuite/gas/riscv/fence-tso.s
+++ b/gas/testsuite/gas/riscv/fence-tso.s
@@ -1,2 +1,0 @@
-target:
-	fence.tso

--- a/gas/testsuite/gas/riscv/fence.d
+++ b/gas/testsuite/gas/riscv/fence.d
@@ -8,4 +8,6 @@ Disassembly of section .text:
 
 0+000 <target>:
 [ 	]+0:[ 	]+8330000f[ 	]+fence.tso
-
+[ 	]+4:[ 	]+0100000f[ 	]+pause
+[ 	]+8:[ 	]+0ff0000f[ 	]+fence
+[ 	]+c:[ 	]+0ff0000f[ 	]+fence

--- a/gas/testsuite/gas/riscv/fence.s
+++ b/gas/testsuite/gas/riscv/fence.s
@@ -1,0 +1,10 @@
+target:
+	# fence w, w with fm[31:28] = 0x1000
+	fence.tso
+
+	# fence w, 0
+	pause
+
+	# fence iorw, iorw
+	fence
+	fence	iorw, iorw

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -343,6 +343,7 @@ const struct riscv_opcode riscv_opcodes[] =
 {"sw",          0, INSN_CLASS_C,   "Ct,Ck(Cs)",  MATCH_C_SW, MASK_C_SW, match_opcode, INSN_ALIAS|INSN_DREF|INSN_4_BYTE },
 {"sw",          0, INSN_CLASS_I,   "t,q(s)",  MATCH_SW, MASK_SW, match_opcode, INSN_DREF|INSN_4_BYTE },
 {"sw",          0, INSN_CLASS_I,   "t,A,s",  0, (int) M_SW, match_never, INSN_MACRO },
+{"pause",       0, INSN_CLASS_I,   "",  MATCH_FENCE | (0x1 << OP_SH_PRED) | (0x0 << OP_SH_SUCC), MASK_FENCE | MASK_RD | MASK_RS1 | MASK_IMM, match_opcode, 0 }, /* fence w, 0 */
 {"fence",       0, INSN_CLASS_I,   "",  MATCH_FENCE | MASK_PRED | MASK_SUCC, MASK_FENCE | MASK_RD | MASK_RS1 | MASK_IMM, match_opcode, INSN_ALIAS },
 {"fence",       0, INSN_CLASS_I,   "P,Q",  MATCH_FENCE, MASK_FENCE | MASK_RD | MASK_RS1 | (MASK_IMM & ~MASK_PRED & ~MASK_SUCC), match_opcode, 0 },
 {"fence.i",     0, INSN_CLASS_I,   "",  MATCH_FENCE_I, MASK_FENCE | MASK_RD | MASK_RS1 | MASK_IMM, match_opcode, 0 },


### PR DESCRIPTION
There is a problem here - Should we regard the pause instruction as an alias of hint fence?  Here is the assembly syntax of fence instruction,

fence  [i][o][r][w], [i][o][r][w]

The current assembler doesn't allow the pred and succ fields are set to `0`.  Therefore, if the pause is an alias of fence, then we will get `fence   w,unknown` when the option "-Mno-aliases" is set to objdump.

On the other hand, should we accept that the pred and succ fields can be set to `0` by the assembly fence instruction?  That is,

fence 0, w  --> illegal for now, should this be legal?
fence w, 0  --> same as above
fence 0, 0  --> same as above

If it is accepted, then it's fine to regard the pause instruction as an alias.

However, this patch doesn't regard the pause as an alias, and the `0` pred and succ are not accepted for the assembly fence.