### PR TITLE
Big endian support in binutils

### DIFF
--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -1155,7 +1155,7 @@ case "${targ}" in
     ;;
 
 #ifdef BFD64
-  riscv_be-*-* | riscv32*_be-*-*)
+  riscvbe-*-* | riscv32be*-*-*)
     targ_defvec=riscv_elf32_be_vec
     targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true
@@ -1165,7 +1165,7 @@ case "${targ}" in
     targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true
     ;;
-  riscv64*_be-*-*)
+  riscv64be*-*-*)
     targ_defvec=riscv_elf64_be_vec
     targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true

--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -1157,12 +1157,12 @@ case "${targ}" in
 #ifdef BFD64
   riscv-*-* | riscv32*-*-*)
     targ_defvec=riscv_elf32_vec
-    targ_selvecs="riscv_elf32_vec riscv_elf64_vec"
+    targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true
     ;;
   riscv64*-*-*)
     targ_defvec=riscv_elf64_vec
-    targ_selvecs="riscv_elf32_vec riscv_elf64_vec"
+    targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true
     ;;
 #endif

--- a/bfd/config.bfd
+++ b/bfd/config.bfd
@@ -1155,8 +1155,18 @@ case "${targ}" in
     ;;
 
 #ifdef BFD64
+  riscv_be-*-* | riscv32*_be-*-*)
+    targ_defvec=riscv_elf32_be_vec
+    targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
+    want64=true
+    ;;
   riscv-*-* | riscv32*-*-*)
     targ_defvec=riscv_elf32_vec
+    targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
+    want64=true
+    ;;
+  riscv64*_be-*-*)
+    targ_defvec=riscv_elf64_be_vec
     targ_selvecs="riscv_elf32_vec riscv_elf64_vec riscv_elf32_be_vec riscv_elf64_be_vec"
     want64=true
     ;;

--- a/bfd/configure
+++ b/bfd/configure
@@ -14891,6 +14891,8 @@ do
     pru_elf32_vec)		 tb="$tb elf32-pru.lo elf32.lo $elf" ;;
     riscv_elf32_vec)		 tb="$tb elf32-riscv.lo elfxx-riscv.lo elf32.lo $elf" ;;
     riscv_elf64_vec)		 tb="$tb elf64-riscv.lo elf64.lo elfxx-riscv.lo elf32.lo $elf"; target_size=64 ;;
+    riscv_elf32_be_vec)		 tb="$tb elf32-riscv.lo elfxx-riscv.lo elf32.lo $elf" ;;
+    riscv_elf64_be_vec)		 tb="$tb elf64-riscv.lo elf64.lo elfxx-riscv.lo elf32.lo $elf"; target_size=64 ;;
     rl78_elf32_vec)		 tb="$tb elf32-rl78.lo elf32.lo $elf" ;;
     rs6000_xcoff64_vec)		 tb="$tb coff64-rs6000.lo aix5ppc-core.lo $xcoff"; target_size=64 ;;
     rs6000_xcoff64_aix_vec)	 tb="$tb coff64-rs6000.lo aix5ppc-core.lo $xcoff"; target_size=64 ;;

--- a/bfd/configure.ac
+++ b/bfd/configure.ac
@@ -627,6 +627,8 @@ do
     pru_elf32_vec)		 tb="$tb elf32-pru.lo elf32.lo $elf" ;;
     riscv_elf32_vec)		 tb="$tb elf32-riscv.lo elfxx-riscv.lo elf32.lo $elf" ;;
     riscv_elf64_vec)		 tb="$tb elf64-riscv.lo elf64.lo elfxx-riscv.lo elf32.lo $elf"; target_size=64 ;;
+    riscv_elf32_be_vec)		 tb="$tb elf32-riscv.lo elfxx-riscv.lo elf32.lo $elf" ;;
+    riscv_elf64_be_vec)		 tb="$tb elf64-riscv.lo elf64.lo elfxx-riscv.lo elf32.lo $elf"; target_size=64 ;;
     rl78_elf32_vec)		 tb="$tb elf32-rl78.lo elf32.lo $elf" ;;
     rs6000_xcoff64_vec)		 tb="$tb coff64-rs6000.lo aix5ppc-core.lo $xcoff"; target_size=64 ;;
     rs6000_xcoff64_aix_vec)	 tb="$tb coff64-rs6000.lo aix5ppc-core.lo $xcoff"; target_size=64 ;;

--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -4266,7 +4266,8 @@ static bfd_boolean
 riscv_elf_object_p (bfd *abfd)
 {
   /* There are only two mach types in RISCV currently.  */
-  if (strcmp (abfd->xvec->name, "elf32-littleriscv") == 0)
+  if (strcmp (abfd->xvec->name, "elf32-littleriscv") == 0 ||
+      strcmp (abfd->xvec->name, "elf32-bigriscv") == 0)
     bfd_default_set_arch_mach (abfd, bfd_arch_riscv, bfd_mach_riscv32);
   else
     bfd_default_set_arch_mach (abfd, bfd_arch_riscv, bfd_mach_riscv64);
@@ -4285,6 +4286,8 @@ riscv_elf_obj_attrs_arg_type (int tag)
 
 #define TARGET_LITTLE_SYM		riscv_elfNN_vec
 #define TARGET_LITTLE_NAME		"elfNN-littleriscv"
+#define TARGET_BIG_SYM			riscv_elfNN_be_vec
+#define TARGET_BIG_NAME			"elfNN-bigriscv"
 
 #define elf_backend_reloc_type_class	     riscv_reloc_type_class
 

--- a/bfd/targets.c
+++ b/bfd/targets.c
@@ -846,6 +846,8 @@ extern const bfd_target powerpc_xcoff_vec;
 extern const bfd_target pru_elf32_vec;
 extern const bfd_target riscv_elf32_vec;
 extern const bfd_target riscv_elf64_vec;
+extern const bfd_target riscv_elf32_be_vec;
+extern const bfd_target riscv_elf64_be_vec;
 extern const bfd_target rl78_elf32_vec;
 extern const bfd_target rs6000_xcoff64_vec;
 extern const bfd_target rs6000_xcoff64_aix_vec;
@@ -1243,6 +1245,8 @@ static const bfd_target * const _bfd_target_vector[] =
 #ifdef BFD64
 	&riscv_elf32_vec,
 	&riscv_elf64_vec,
+	&riscv_elf32_be_vec,
+	&riscv_elf64_be_vec,
 #endif
 	&rl78_elf32_vec,
 

--- a/config.sub
+++ b/config.sub
@@ -1227,7 +1227,7 @@ case $cpu-$vendor in
 			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
 			| pru \
 			| pyramid \
-			| riscv | riscv32 | riscv64 \
+			| riscv | riscv32 | riscv64 | riscv_be | riscv32_be | riscv64_be \
 			| rl78 | romp | rs6000 | rx \
 			| score \
 			| sh | shl \

--- a/config.sub
+++ b/config.sub
@@ -1227,7 +1227,7 @@ case $cpu-$vendor in
 			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
 			| pru \
 			| pyramid \
-			| riscv | riscv32 | riscv64 | riscv_be | riscv32_be | riscv64_be \
+			| riscv | riscv32 | riscv64 | riscvbe | riscv32be | riscv64be \
 			| rl78 | romp | rs6000 | rx \
 			| score \
 			| sh | shl \

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -3465,14 +3465,14 @@ md_convert_frag_branch (fragS *fragp)
       insn = bfd_getl32 (buf);
       insn ^= MATCH_BEQ ^ MATCH_BNE;
       insn |= ENCODE_SBTYPE_IMM (8);
-      md_number_to_chars ((char *) buf, insn, 4);
+      bfd_putl32 (insn, buf);
       buf += 4;
 
     jump:
       /* Jump to the target.  */
       fixp = fix_new_exp (fragp, buf - (bfd_byte *)fragp->fr_literal,
 			  4, &exp, FALSE, BFD_RELOC_RISCV_JMP);
-      md_number_to_chars ((char *) buf, MATCH_JAL, 4);
+      bfd_putl32 (MATCH_JAL, buf);
       buf += 4;
       break;
 

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -397,7 +397,10 @@ static char *expr_end;
 const char *
 riscv_target_format (void)
 {
-  return xlen == 64 ? "elf64-littleriscv" : "elf32-littleriscv";
+  if (target_big_endian)
+    return xlen == 64 ? "elf64-bigriscv" : "elf32-bigriscv";
+  else
+    return xlen == 64 ? "elf64-littleriscv" : "elf32-littleriscv";
 }
 
 /* Return the length of instruction INSN.  */
@@ -426,7 +429,7 @@ static void
 install_insn (const struct riscv_cl_insn *insn)
 {
   char *f = insn->frag->fr_literal + insn->where;
-  md_number_to_chars (f, insn->insn_opcode, insn_length (insn));
+  number_to_chars_littleendian (f, insn->insn_opcode, insn_length (insn));
 }
 
 /* Move INSN to offset WHERE in FRAG.  Adjust the fixups accordingly
@@ -2596,7 +2599,10 @@ md_atof (int type, char *litP, int *sizeP)
 void
 md_number_to_chars (char *buf, valueT val, int n)
 {
-  number_to_chars_littleendian (buf, val, n);
+  if (target_big_endian)
+    number_to_chars_bigendian (buf, val, n);
+  else
+    number_to_chars_littleendian (buf, val, n);
 }
 
 const char *md_shortopts = "O::g::G:";
@@ -2615,6 +2621,8 @@ enum options
   OPTION_NO_CSR_CHECK,
   OPTION_MISA_SPEC,
   OPTION_MPRIV_SPEC,
+  OPTION_BIG_ENDIAN,
+  OPTION_LITTLE_ENDIAN,
   OPTION_END_OF_ENUM
 };
 
@@ -2633,6 +2641,8 @@ struct option md_longopts[] =
   {"mno-csr-check", no_argument, NULL, OPTION_NO_CSR_CHECK},
   {"misa-spec", required_argument, NULL, OPTION_MISA_SPEC},
   {"mpriv-spec", required_argument, NULL, OPTION_MPRIV_SPEC},
+  {"mbig-endian", no_argument, NULL, OPTION_BIG_ENDIAN},
+  {"mlittle-endian", no_argument, NULL, OPTION_LITTLE_ENDIAN},
 
   {NULL, no_argument, NULL, 0}
 };
@@ -2726,6 +2736,14 @@ md_parse_option (int c, const char *arg)
 
     case OPTION_MPRIV_SPEC:
       return riscv_set_default_priv_spec (arg);
+
+    case OPTION_BIG_ENDIAN:
+      target_big_endian = 1;
+      break;
+
+    case OPTION_LITTLE_ENDIAN:
+      target_big_endian = 0;
+      break;
 
     default:
       return 0;

--- a/gas/doc/as.texi
+++ b/gas/doc/as.texi
@@ -537,6 +537,7 @@ gcc(1), ld(1), and the Info entries for @file{binutils} and @file{ld}.
    [@b{-fpic}|@b{-fPIC}|@b{-fno-pic}]
    [@b{-march}=@var{ISA}]
    [@b{-mabi}=@var{ABI}]
+   [@b{-mlittle}|@b{-mlittle-endian}|@b{-mbig}|@b{-mbig-endian}]
 @end ifset
 @ifset RL78
 

--- a/gas/doc/c-riscv.texi
+++ b/gas/doc/c-riscv.texi
@@ -99,6 +99,16 @@ read-only CSR can not be written by the CSR instructions.
 @cindex @samp{-mno-csr-check} option, RISC-V
 @item -mno-csr-check
 Don't do CSR cheching.
+
+@cindex @samp{-mlittle} option, RISC-V
+@cindex @samp{-mlittle-endian} option, RISC-V
+@item -mlittle, -mlittle-endian
+Generate code for a little endian machine.
+
+@cindex @samp{-mbig} option, RISC-V
+@cindex @samp{-mbig-endian} option, RISC-V
+@item -mbig, -mbig-endian
+Generate code for a big endian machine.
 @end table
 @c man end
 

--- a/ld/Makefile.am
+++ b/ld/Makefile.am
@@ -266,6 +266,9 @@ ALL_EMULATION_SOURCES = \
 	eelf32lriscv.c \
 	eelf32lriscv_ilp32f.c \
 	eelf32lriscv_ilp32.c \
+	eelf32briscv.c \
+	eelf32briscv_ilp32f.c \
+	eelf32briscv_ilp32.c \
 	eelf32rl78.c \
 	eelf32rx.c \
 	eelf32rx_linux.c \
@@ -436,6 +439,9 @@ ALL_64_EMULATION_SOURCES = \
 	eelf64lriscv.c \
 	eelf64lriscv_lp64f.c \
 	eelf64lriscv_lp64.c \
+	eelf64briscv.c \
+	eelf64briscv_lp64f.c \
+	eelf64briscv_lp64.c \
 	eelf64ltsmip.c \
 	eelf64ltsmip_fbsd.c \
 	eelf64mmix.c \
@@ -752,6 +758,9 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv_ilp32f.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv_ilp32.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32f.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rl78.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rx.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rx_linux.Pc@am__quote@
@@ -918,6 +927,9 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv_lp64f.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv_lp64.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64f.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ltsmip.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ltsmip_fbsd.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64mmix.Pc@am__quote@

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -515,6 +515,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -749,6 +750,9 @@ ALL_EMULATION_SOURCES = \
 	eelf32lriscv.c \
 	eelf32lriscv_ilp32f.c \
 	eelf32lriscv_ilp32.c \
+	eelf32briscv.c \
+	eelf32briscv_ilp32f.c \
+	eelf32briscv_ilp32.c \
 	eelf32rl78.c \
 	eelf32rx.c \
 	eelf32rx_linux.c \
@@ -918,6 +922,9 @@ ALL_64_EMULATION_SOURCES = \
 	eelf64lriscv.c \
 	eelf64lriscv_lp64f.c \
 	eelf64lriscv_lp64.c \
+	eelf64briscv.c \
+	eelf64briscv_lp64f.c \
+	eelf64briscv_lp64.c \
 	eelf64ltsmip.c \
 	eelf64ltsmip_fbsd.c \
 	eelf64mmix.c \
@@ -1266,6 +1273,9 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32bfinfd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32bmip.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32bmipn32.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32f.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32bsmip.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32btsmip.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32btsmip_fbsd.Po@am__quote@
@@ -1351,6 +1361,9 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64alpha_nbsd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64bmip.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64bpf.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64f.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64btsmip.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64btsmip_fbsd.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64hppa.Po@am__quote@
@@ -2347,6 +2360,9 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv_ilp32f.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32lriscv_ilp32.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32f.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32briscv_ilp32.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rl78.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rx.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf32rx_linux.Pc@am__quote@
@@ -2513,6 +2529,9 @@ $(ALL_EMULATION_SOURCES) $(ALL_64_EMULATION_SOURCES): $(GEN_DEPENDS)
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv_lp64f.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64lriscv_lp64.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64f.Pc@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64briscv_lp64.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ltsmip.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64ltsmip_fbsd.Pc@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/eelf64mmix.Pc@am__quote@

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -740,7 +740,7 @@ powerpc-*-lynxos*)	targ_emul=ppclynx
 			;;
 pru*-*-*)		targ_emul=pruelf
 			;;
-riscv32*_be-*-linux*)	targ_emul=elf32briscv
+riscv32be*-*-linux*)	targ_emul=elf32briscv
 			targ_extra_emuls="elf32briscv_ilp32f elf32briscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
@@ -748,7 +748,7 @@ riscv32*-*-linux*)	targ_emul=elf32lriscv
 			targ_extra_emuls="elf32lriscv_ilp32f elf32lriscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
-riscv_be-*-* | riscv32*_be-*-*)
+riscvbe-*-* | riscv32be*-*-*)
 			targ_emul=elf32briscv
 			targ_extra_emuls="elf64briscv elf32lriscv elf64lriscv"
 			targ_extra_libpath=$targ_extra_emuls
@@ -758,7 +758,7 @@ riscv-*-* | riscv32*-*-*)
 			targ_extra_emuls="elf64lriscv elf32briscv elf64briscv"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
-riscv64*_be-*-linux*)	targ_emul=elf64briscv
+riscv64be*-*-linux*)	targ_emul=elf64briscv
 			targ_extra_emuls="elf64briscv_lp64f elf64briscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
@@ -766,7 +766,7 @@ riscv64*-*-linux*)	targ_emul=elf64lriscv
 			targ_extra_emuls="elf64lriscv_lp64f elf64lriscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
-riscv64*_be-*-*)	targ_emul=elf64briscv
+riscv64be*-*-*)		targ_emul=elf64briscv
 			targ_extra_emuls="elf32briscv elf64lriscv elf32lriscv"
 			targ_extra_libpath=$targ_extra_emuls
 			;;

--- a/ld/configure.tgt
+++ b/ld/configure.tgt
@@ -740,21 +740,38 @@ powerpc-*-lynxos*)	targ_emul=ppclynx
 			;;
 pru*-*-*)		targ_emul=pruelf
 			;;
+riscv32*_be-*-linux*)	targ_emul=elf32briscv
+			targ_extra_emuls="elf32briscv_ilp32f elf32briscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64"
+			targ_extra_libpath=$targ_extra_emuls
+			;;
 riscv32*-*-linux*)	targ_emul=elf32lriscv
-			targ_extra_emuls="elf32lriscv_ilp32f elf32lriscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64"
+			targ_extra_emuls="elf32lriscv_ilp32f elf32lriscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64"
+			targ_extra_libpath=$targ_extra_emuls
+			;;
+riscv_be-*-* | riscv32*_be-*-*)
+			targ_emul=elf32briscv
+			targ_extra_emuls="elf64briscv elf32lriscv elf64lriscv"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
 riscv-*-* | riscv32*-*-*)
 			targ_emul=elf32lriscv
-			targ_extra_emuls="elf64lriscv"
+			targ_extra_emuls="elf64lriscv elf32briscv elf64briscv"
+			targ_extra_libpath=$targ_extra_emuls
+			;;
+riscv64*_be-*-linux*)	targ_emul=elf64briscv
+			targ_extra_emuls="elf64briscv_lp64f elf64briscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32 elf64lriscv elf64lriscv_lp64f elf64lriscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
 riscv64*-*-linux*)	targ_emul=elf64lriscv
-			targ_extra_emuls="elf64lriscv_lp64f elf64lriscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32"
+			targ_extra_emuls="elf64lriscv_lp64f elf64lriscv_lp64 elf32lriscv elf32lriscv_ilp32f elf32lriscv_ilp32 elf64briscv elf64briscv_lp64f elf64briscv_lp64 elf32briscv elf32briscv_ilp32f elf32briscv_ilp32"
+			targ_extra_libpath=$targ_extra_emuls
+			;;
+riscv64*_be-*-*)	targ_emul=elf64briscv
+			targ_extra_emuls="elf32briscv elf64lriscv elf32lriscv"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
 riscv64*-*-*)		targ_emul=elf64lriscv
-			targ_extra_emuls="elf32lriscv"
+			targ_extra_emuls="elf32lriscv elf64briscv elf32briscv"
 			targ_extra_libpath=$targ_extra_emuls
 			;;
 rs6000-*-aix[5-9]*)	targ_emul=aix5rs6

--- a/ld/emulparams/elf32briscv.sh
+++ b/ld/emulparams/elf32briscv.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf32lriscv.sh
+OUTPUT_FORMAT="elf32-bigriscv"

--- a/ld/emulparams/elf32briscv_ilp32.sh
+++ b/ld/emulparams/elf32briscv_ilp32.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf32lriscv_ilp32.sh
+OUTPUT_FORMAT="elf32-bigriscv"

--- a/ld/emulparams/elf32briscv_ilp32f.sh
+++ b/ld/emulparams/elf32briscv_ilp32f.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf32lriscv_ilp32f.sh
+OUTPUT_FORMAT="elf32-bigriscv"

--- a/ld/emulparams/elf64briscv.sh
+++ b/ld/emulparams/elf64briscv.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf64lriscv.sh
+OUTPUT_FORMAT="elf64-bigriscv"

--- a/ld/emulparams/elf64briscv_lp64.sh
+++ b/ld/emulparams/elf64briscv_lp64.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf64lriscv_lp64.sh
+OUTPUT_FORMAT="elf64-bigriscv"

--- a/ld/emulparams/elf64briscv_lp64f.sh
+++ b/ld/emulparams/elf64briscv_lp64f.sh
@@ -1,0 +1,2 @@
+source_sh ${srcdir}/emulparams/elf64lriscv_lp64f.sh
+OUTPUT_FORMAT="elf64-bigriscv"


### PR DESCRIPTION
This should probably not be merged into `riscv-binutils-2.35` as I suppose that is an upstreams tracking branch.  But maybe a new branch alongside `riscv-binutils-2.35-rvb`?  My goal here is to get more visibility for the patchset so that people who need it can find it more easily, and maybe even get some comments on it.  :smile:

Of note here is the function `perform_relocation` which contains a heuristic for determining if a relocation is against data (which has natural byte ordering, i.e. `bfd_get`/`bfd_put` should be used), or instructions (which may have unnatural byte ordering, and so require different load/store functions).  The heuristic is that any multi-byte relocation which updates with a mask must be an instruction.  This is similar to what aarch64 (which has the same problem) does in `_bfd_aarch64_elf_put_addend`, although aarch64 can restrict the instruction case to 32-bit relocations only as they have a fixed instruction length.