### PR TITLE
[RVB] Handle sub-extension and version info for B.

### DIFF
--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -2725,7 +2725,7 @@ riscv_merge_std_ext (bfd *ibfd,
 	  && ((find_in->major_version != find_out->major_version)
 	      || (find_in->minor_version != find_out->minor_version)))
 	{
-	  riscv_version_mismatch (ibfd, in, out);
+	  riscv_version_mismatch (ibfd, find_in, find_out);
 	  return FALSE;
 	}
 

--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -1425,7 +1425,8 @@ riscv_parse_prefixed_ext (riscv_parse_subset_t *rps,
 
 static const char * const riscv_std_z_ext_strtab[] =
   {
-    "zicsr", NULL
+    "zicsr", 
+    "zbb", "zbs", "zba", "zbp", "zbe", "zbf", "zbc", "zbr", "zbm", "zbt", NULL
   };
 
 /* Same as `riscv_std_z_ext_strtab', but for S-class extensions.  */

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -326,7 +326,8 @@ riscv_get_default_ext_version (const char *name,
         && ext->name
         && strcmp (ext->name, name) == 0)
     {
-      if (ext->isa_spec_class == default_isa_spec)
+      if (ext->isa_spec_class == ISA_SPEC_CLASS_NONE
+	  || ext->isa_spec_class == default_isa_spec)
        {
          *major_version = ext->major_version;
          *minor_version = ext->minor_version;

--- a/gas/testsuite/gas/riscv/attribute-15-unratified.d
+++ b/gas/testsuite/gas/riscv/attribute-15-unratified.d
@@ -1,0 +1,6 @@
+#as: -march-attr -march=rv32ifv_zvamo_zvediv_zvlsseg_zvqmac
+#readelf: -A
+#source: empty.s
+Attribute Section: riscv
+File Attributes
+  Tag_RISCV_arch: ".*_v1p0_zvamo1p0_zvediv1p0_zvlsseg1p0_zvqmac1p0"

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -1150,6 +1150,18 @@ const struct riscv_ext_version riscv_ext_version_table[] =
 {"zicsr", ISA_SPEC_CLASS_20191213, 2, 0},
 {"zicsr", ISA_SPEC_CLASS_20190608, 2, 0},
 
+{"b",     ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbb",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbs",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zba",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbp",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbe",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbf",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbc",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbr",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbm",   ISA_SPEC_CLASS_NONE, 0, 92},
+{"zbt",   ISA_SPEC_CLASS_NONE, 0, 92},
+
 /* Terminate the list.  */
 {NULL, 0, 0, 0}
 };

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -1140,15 +1140,18 @@ const struct riscv_ext_version riscv_ext_version_table[] =
 {"p", ISA_SPEC_CLASS_20190608, 0, 2},
 {"p", ISA_SPEC_CLASS_2P2,      0, 1},
 
-{"v", ISA_SPEC_CLASS_20191213, 0, 7},
-{"v", ISA_SPEC_CLASS_20190608, 0, 7},
-{"v", ISA_SPEC_CLASS_2P2,      0, 7},
+{"v", ISA_SPEC_CLASS_NONE,     1, 0},
 
 {"n", ISA_SPEC_CLASS_20190608, 1, 1},
 {"n", ISA_SPEC_CLASS_2P2,      1, 1},
 
 {"zicsr", ISA_SPEC_CLASS_20191213, 2, 0},
 {"zicsr", ISA_SPEC_CLASS_20190608, 2, 0},
+
+{"zvamo",   ISA_SPEC_CLASS_NONE, 1, 0},
+{"zvediv",  ISA_SPEC_CLASS_NONE, 1, 0},
+{"zvlsseg", ISA_SPEC_CLASS_NONE, 1, 0},
+{"zvqmac",  ISA_SPEC_CLASS_NONE, 1, 0},
 
 {"b",     ISA_SPEC_CLASS_NONE, 0, 92},
 {"zbb",   ISA_SPEC_CLASS_NONE, 0, 92},


### PR DESCRIPTION
I created an branch based on 2.32 with RVB, and merge most patch into one, but keep the author info, including list Maxim Blinov as co-author.

And based on the branch made few improvements for emitting right version info of B-extensions and parsing sub-extensions.