### PR TITLE
Backport fix from FSF to fix configure problem caused by ctf patches.

### DIFF
--- a/gdb/ChangeLog
+++ b/gdb/ChangeLog
@@ -1,3 +1,8 @@
+2020-11-28  Alex Richardson  <Alexander.Richardson@cl.cam.ac.uk>
+
+	* acincludde.m4 (GDB_AC_CHECK_BFD): Include string.h in the test
+	program.
+
 2020-10-24  Joel Brobecker  <brobecker@adacore.com>
 
 	* version.in: Set GDB version number to 10.1.

--- a/gdb/acinclude.m4
+++ b/gdb/acinclude.m4
@@ -362,6 +362,7 @@ AC_DEFUN([GDB_AC_CHECK_BFD], [
   AC_CACHE_CHECK([$1], [$2],
   [AC_TRY_LINK(
   [#include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "$4"
   ],

--- a/gdb/configure
+++ b/gdb/configure
@@ -16818,6 +16818,7 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "elf-bfd.h"
 
@@ -16929,6 +16930,7 @@ else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdlib.h>
+  #include <string.h>
   #include "bfd.h"
   #include "mach-o.h"
 


### PR DESCRIPTION
Including bfd.h now also requires including string.h.  Fixes riscv-gnu-toolchain #867.
