### PR TITLE
Fix crash when disassembling non-ELF files

### DIFF
--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -597,17 +597,22 @@ riscv_get_disassembler (bfd *abfd)
      privileged attributes.  */
   if (abfd)
     {
-      const char *sec_name = get_elf_backend_data (abfd)->obj_attrs_section;
-      if (bfd_get_section_by_name (abfd, sec_name) != NULL)
+      const struct elf_backend_data *ebd = get_elf_backend_data (abfd);
+
+      if (ebd)
         {
-	  obj_attribute *attr = elf_known_obj_attributes_proc (abfd);
-	  unsigned int Tag_a = Tag_RISCV_priv_spec;
-	  unsigned int Tag_b = Tag_RISCV_priv_spec_minor;
-	  unsigned int Tag_c = Tag_RISCV_priv_spec_revision;
-	  riscv_get_priv_spec_class_from_numbers (attr[Tag_a].i,
-						  attr[Tag_b].i,
-						  attr[Tag_c].i,
-						  &default_priv_spec);
+          const char *sec_name = ebd->obj_attrs_section;
+          if (bfd_get_section_by_name (abfd, sec_name) != NULL)
+            {
+              obj_attribute *attr = elf_known_obj_attributes_proc (abfd);
+              unsigned int Tag_a = Tag_RISCV_priv_spec;
+              unsigned int Tag_b = Tag_RISCV_priv_spec_minor;
+              unsigned int Tag_c = Tag_RISCV_priv_spec_revision;
+              riscv_get_priv_spec_class_from_numbers (attr[Tag_a].i,
+                                  attr[Tag_b].i,
+                                  attr[Tag_c].i,
+                                  &default_priv_spec);
+            }
         }
     }
    return print_insn_riscv;


### PR DESCRIPTION
The return value of get_elf_backend_data was used without checking for
NULL. Since this function seems to return NULL for non-ELF files, it
caused a crash when disassembling binary files. This commit adds a
NULL-check to fix this.